### PR TITLE
multi click selection + misc focus handling

### DIFF
--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -2,10 +2,12 @@
 
 use bevy::{
     color::palettes::css::{LIGHT_GOLDENROD_YELLOW, MAROON, RED},
-    prelude::*, text::cosmic_text::Align,
+    prelude::*,
+    text::cosmic_text::Align,
 };
 use bevy_ui_text_input::{
-    SubmitTextEvent, TextInputBuffer, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt, TextInputStyle, TextSubmissionEvent
+    SubmitTextEvent, TextInputBuffer, TextInputMode, TextInputNode, TextInputPlugin,
+    TextInputPrompt, TextInputStyle, TextSubmissionEvent,
 };
 
 fn main() {
@@ -280,8 +282,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
                             ..Default::default()
                         })
                         .with_children(|commands| {
-                            
-                                commands
+                            commands
                             .spawn((
                                 Node {
                                     border: UiRect::all(Val::Px(2.)),
@@ -304,7 +305,6 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
                                 },
                             )
                             .with_child(Text::new(format!("wrap")));
-                            
                         });
 
                         commands
@@ -314,7 +314,6 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
                             ..Default::default()
                         })
                         .with_children(|commands| {
-                            
                             commands
                             .spawn((
                                 Node {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -9,7 +9,6 @@ use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
 use bevy::ecs::component::Component;
 use bevy::ecs::system::Commands;
-use bevy::input::mouse::MouseMotion;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,14 +1,14 @@
 use arboard::Clipboard;
+use bevy::ecs::component::Component;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::event::EventReader;
 use bevy::ecs::event::EventWriter;
 use bevy::ecs::observer::Trigger;
+use bevy::ecs::system::Commands;
 use bevy::ecs::system::Local;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
-use bevy::ecs::component::Component;
-use bevy::ecs::system::Commands;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
@@ -18,9 +18,9 @@ use bevy::input_focus::InputFocus;
 use bevy::math::Rect;
 use bevy::picking::events::Click;
 use bevy::picking::events::Drag;
+use bevy::picking::events::Move;
 use bevy::picking::events::Pointer;
 use bevy::picking::events::Pressed;
-use bevy::picking::events::Move;
 use bevy::picking::hover::HoverMap;
 use bevy::picking::pointer::PointerButton;
 use bevy::text::cosmic_text::Action;
@@ -469,7 +469,7 @@ pub(crate) fn on_drag_text_input(
         return;
     };
 
-    if !input.is_enabled {
+    if !input.is_enabled || !input.focus_on_pointer_down {
         return;
     }
 
@@ -620,11 +620,11 @@ pub fn on_multi_click_set_selection(
 
     let entity = click.target();
 
-    if let Ok(input) = text_input_nodes.get(click.target()) {
-        if !input.is_enabled || !input.focus_on_pointer_down {
-            return;
-        }
-    } else {
+    let Ok(input) = text_input_nodes.get(click.target()) else {
+        return;
+    };
+
+    if !input.is_enabled || !input.focus_on_pointer_down {
         return;
     }
 
@@ -632,7 +632,9 @@ pub fn on_multi_click_set_selection(
     if let Ok(mut multi_click_data) = multi_click_datas.get_mut(entity) {
         if now - multi_click_data.last_click_time <= MULTI_CLICK_TIMER {
             if let Ok(mut buffer) = buffers.get_mut(entity) {
-                let mut editor = buffer.editor.borrow_with(&mut text_input_pipeline.font_system);
+                let mut editor = buffer
+                    .editor
+                    .borrow_with(&mut text_input_pipeline.font_system);
                 match multi_click_data.times {
                     1 => {
                         multi_click_data.times += 1;
@@ -653,13 +655,16 @@ pub fn on_multi_click_set_selection(
                         }
                         return;
                     }
-                    _ => ()
+                    _ => (),
                 }
             }
         }
     }
     if let Ok(mut entity) = commands.get_entity(entity) {
-        entity.try_insert(MultiClickData { last_click_time: now, times: 1 });
+        entity.try_insert(MultiClickData {
+            last_click_time: now,
+            times: 1,
+        });
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -7,6 +7,9 @@ use bevy::ecs::system::Local;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
+use bevy::ecs::component::Component;
+use bevy::ecs::system::Commands;
+use bevy::input::mouse::MouseMotion;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
@@ -14,9 +17,11 @@ use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
 use bevy::input_focus::InputFocus;
 use bevy::math::Rect;
+use bevy::picking::events::Click;
 use bevy::picking::events::Drag;
 use bevy::picking::events::Pointer;
 use bevy::picking::events::Pressed;
+use bevy::picking::events::Move;
 use bevy::picking::hover::HoverMap;
 use bevy::picking::pointer::PointerButton;
 use bevy::text::cosmic_text::Action;
@@ -505,7 +510,7 @@ pub(crate) fn on_text_input_pressed(
         return;
     };
 
-    if !input.is_enabled {
+    if !input.is_enabled || !input.focus_on_pointer_down {
         return;
     }
 
@@ -571,5 +576,96 @@ pub fn mouse_wheel_scroll(
                 };
             }
         }
+    }
+}
+
+pub fn clear_selection_on_focus_change(
+    input_focus: Res<InputFocus>,
+    mut text_input_pipeline: ResMut<TextInputPipeline>,
+    mut buffers: Query<&mut TextInputBuffer>,
+    mut previous_input_focus: Local<Option<Entity>>,
+) {
+    if *previous_input_focus != input_focus.0 {
+        if let Some(entity) = *previous_input_focus {
+            if let Ok(mut buffer) = buffers.get_mut(entity) {
+                buffer
+                    .editor
+                    .borrow_with(&mut text_input_pipeline.font_system)
+                    .set_selection(Selection::None);
+            }
+        }
+        *previous_input_focus = input_focus.0;
+    }
+}
+
+const MULTI_CLICK_TIMER: f32 = 0.5; // seconds
+
+#[derive(Component)]
+pub struct MultiClickData {
+    last_click_time: f32,
+    times: usize,
+}
+
+pub fn on_multi_click_set_selection(
+    click: Trigger<Pointer<Click>>,
+    time: Res<Time>,
+    text_input_nodes: Query<&TextInputNode>,
+    mut multi_click_datas: Query<&mut MultiClickData>,
+    mut text_input_pipeline: ResMut<TextInputPipeline>,
+    mut buffers: Query<&mut TextInputBuffer>,
+    mut commands: Commands,
+) {
+    if click.button != PointerButton::Primary {
+        return;
+    }
+
+    let entity = click.target();
+
+    if let Ok(input) = text_input_nodes.get(click.target()) {
+        if !input.is_enabled || !input.focus_on_pointer_down {
+            return;
+        }
+    } else {
+        return;
+    }
+
+    let now = time.elapsed_secs();
+    if let Ok(mut multi_click_data) = multi_click_datas.get_mut(entity) {
+        if now - multi_click_data.last_click_time <= MULTI_CLICK_TIMER {
+            if let Ok(mut buffer) = buffers.get_mut(entity) {
+                let mut editor = buffer.editor.borrow_with(&mut text_input_pipeline.font_system);
+                match multi_click_data.times {
+                    1 => {
+                        multi_click_data.times += 1;
+                        multi_click_data.last_click_time = now;
+                        editor.action(Action::Motion(Motion::LeftWord));
+                        let cursor = editor.cursor();
+                        editor.set_selection(Selection::Normal(cursor));
+                        editor.action(Action::Motion(Motion::RightWord));
+                        return;
+                    }
+                    2 => {
+                        editor.action(Action::Motion(Motion::ParagraphStart));
+                        let cursor = editor.cursor();
+                        editor.set_selection(Selection::Normal(cursor));
+                        editor.action(Action::Motion(Motion::ParagraphEnd));
+                        if let Ok(mut entity) = commands.get_entity(entity) {
+                            entity.try_remove::<MultiClickData>();
+                        }
+                        return;
+                    }
+                    _ => ()
+                }
+            }
+        }
+    }
+    if let Ok(mut entity) = commands.get_entity(entity) {
+        entity.try_insert(MultiClickData { last_click_time: now, times: 1 });
+    }
+}
+
+pub fn on_move_clear_multi_click(move_: Trigger<Pointer<Move>>, mut commands: Commands) {
+    if let Ok(mut entity) = commands.get_entity(move_.target()) {
+        entity.try_remove::<MultiClickData>();
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -620,7 +620,7 @@ pub fn on_multi_click_set_selection(
 
     let entity = click.target();
 
-    let Ok(input) = text_input_nodes.get(click.target()) else {
+    let Ok(input) = text_input_nodes.get(entity) else {
         return;
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,14 +121,14 @@ impl Default for TextInputNode {
     }
 }
 
-fn on_add_textinputnode(mut world: DeferredWorld, HookContext { entity, .. }: HookContext) {
+fn on_add_textinputnode(mut world: DeferredWorld, context: HookContext) {
     for mut observer in [
         Observer::new(on_drag_text_input),
         Observer::new(on_text_input_pressed),
         Observer::new(on_multi_click_set_selection),
         Observer::new(on_move_clear_multi_click),
     ] {
-        observer.watch_entity(entity);
+        observer.watch_entity(context.entity);
         world.commands().spawn(observer);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::event::Event;
 use bevy::ecs::observer::Observer;
 use bevy::ecs::query::Changed;
-use bevy::ecs::schedule::common_conditions::resource_changed;
 use bevy::ecs::schedule::IntoScheduleConfigs;
+use bevy::ecs::schedule::common_conditions::resource_changed;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
 use bevy::input_focus::InputFocus;
@@ -25,7 +25,11 @@ use bevy::text::TextColor;
 use bevy::text::cosmic_text::{Align, Buffer, Change, Edit, Editor, Metrics, Wrap};
 use bevy::text::{GlyphAtlasInfo, TextFont};
 use bevy::ui::{Node, RenderUiSystem, UiSystem, extract_text_sections};
-use edit::{clear_selection_on_focus_change, mouse_wheel_scroll, on_drag_text_input, on_multi_click_set_selection, on_text_input_pressed, text_input_edit_system, on_move_clear_multi_click};
+use edit::{
+    clear_selection_on_focus_change, mouse_wheel_scroll, on_drag_text_input,
+    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
+    text_input_edit_system,
+};
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
     TextInputPipeline, remove_dropped_font_atlas_sets_from_text_input_pipeline,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::event::Event;
 use bevy::ecs::observer::Observer;
 use bevy::ecs::query::Changed;
+use bevy::ecs::schedule::common_conditions::resource_changed;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
@@ -24,7 +25,7 @@ use bevy::text::TextColor;
 use bevy::text::cosmic_text::{Align, Buffer, Change, Edit, Editor, Metrics, Wrap};
 use bevy::text::{GlyphAtlasInfo, TextFont};
 use bevy::ui::{Node, RenderUiSystem, UiSystem, extract_text_sections};
-use edit::{mouse_wheel_scroll, on_drag_text_input, on_text_input_pressed, text_input_edit_system};
+use edit::{clear_selection_on_focus_change, mouse_wheel_scroll, on_drag_text_input, on_multi_click_set_selection, on_text_input_pressed, text_input_edit_system, on_move_clear_multi_click};
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
     TextInputPipeline, remove_dropped_font_atlas_sets_from_text_input_pipeline,
@@ -48,6 +49,7 @@ impl Plugin for TextInputPlugin {
                         update_text_input_contents,
                         text_input_system,
                         text_input_prompt_system,
+                        clear_selection_on_focus_change.run_if(resource_changed::<InputFocus>),
                     )
                         .chain()
                         .in_set(UiSystem::PostLayout),
@@ -115,12 +117,14 @@ impl Default for TextInputNode {
     }
 }
 
-fn on_add_textinputnode(mut world: DeferredWorld, context: HookContext) {
+fn on_add_textinputnode(mut world: DeferredWorld, HookContext { entity, .. }: HookContext) {
     for mut observer in [
         Observer::new(on_drag_text_input),
         Observer::new(on_text_input_pressed),
+        Observer::new(on_multi_click_set_selection),
+        Observer::new(on_move_clear_multi_click),
     ] {
-        observer.watch_entity(context.entity);
+        observer.watch_entity(entity);
         world.commands().spawn(observer);
     }
 }


### PR DESCRIPTION
- double clicking selects word, triple clicking selects paragraph (ported from https://github.com/Dimchikkk/bevy_cosmic_edit)
- previous focused input's selection is cleared on focus change
- `TextInputNode.focus_on_pointer_down` now respected for disabling cursor insertion on press, dragging selection, and the newly added double/triple clicking selection
- ran `cargo fmt`

ideally the observers themselves should be added/removed depending on `.is_enabled/.focus_on_pointer_down`, but that can be done in another PR

wasn't really sure where to put `clear_selection_on_focus_change` so just added it to the end of the chain of all the other systems from `edit.rs`, feel free to move it

thanks for this library :pray: 