### PR TITLE
caps lock command handling

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -207,7 +207,7 @@ pub fn text_input_edit_system(
                     Key::Character(str) => {
                         if let Some(char) = str.chars().next() {
                             match char {
-                                'c' => {
+                                'c' | 'C' => {
                                     // copy
                                     if let Ok(ref mut clipboard) = clipboard {
                                         if let Some(text) = editor.copy_selection() {
@@ -215,7 +215,7 @@ pub fn text_input_edit_system(
                                         }
                                     }
                                 }
-                                'x' => {
+                                'x' | 'X' => {
                                     // cut
                                     if let Ok(ref mut clipboard) = clipboard {
                                         if let Some(text) = editor.copy_selection() {
@@ -224,7 +224,7 @@ pub fn text_input_edit_system(
                                     }
                                     editor.delete_selection();
                                 }
-                                'v' => {
+                                'v' | 'V' => {
                                     // paste
                                     if let Ok(ref mut clipboard) = clipboard {
                                         if let Ok(text) = clipboard.get_text() {
@@ -238,17 +238,24 @@ pub fn text_input_edit_system(
                                         }
                                     }
                                 }
-                                'z' => {
+                                'z' | 'Z' => {
+                                    #[cfg(not(target_os = "macos"))]
                                     for action in commands.undo() {
                                         apply_action(&mut editor, action);
                                     }
+                                    #[cfg(target_os = "macos")]
+                                    if shift_pressed {
+                                        for action in commands.redo() {
+                                            apply_action(&mut editor, action);
+                                        }
+                                    }
                                 }
-                                'y' | 'Z' => {
+                                'y' | 'Y' => {
                                     for action in commands.redo() {
                                         apply_action(&mut editor, action);
                                     }
                                 }
-                                'a' => {
+                                'a' | 'A' => {
                                     // select all
                                     editor.action(Action::Motion(Motion::BufferStart));
                                     let cursor = editor.cursor();

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -244,7 +244,7 @@ pub fn text_input_edit_system(
                                         apply_action(&mut editor, action);
                                     }
                                     #[cfg(target_os = "macos")]
-                                    if shift_pressed {
+                                    if *shift_pressed {
                                         for action in commands.redo() {
                                             apply_action(&mut editor, action);
                                         }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -248,6 +248,10 @@ pub fn text_input_edit_system(
                                         for action in commands.redo() {
                                             apply_action(&mut editor, action);
                                         }
+                                    } else {
+                                        for action in commands.undo() {
+                                            apply_action(&mut editor, action);
+                                        }
                                     }
                                 }
                                 'y' | 'Y' => {


### PR DESCRIPTION
commands don't function with caps lock as expected (e.g. like browser inputs) otherwise, tested on ubuntu and mac