### PR TITLE
Use the bevy_platform module on wasm, not the standalone crate

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use bevy::ecs::resource::Resource;
 
 #[cfg(target_arch = "wasm32")]
-use {alloc::sync::Arc, bevy_platform::sync::Mutex, wasm_bindgen_futures::JsFuture};
+use {alloc::sync::Arc, bevy::platform::sync::Mutex, wasm_bindgen_futures::JsFuture};
 
 /// Represents an attempt to read from the clipboard.
 ///


### PR DESCRIPTION
Fixes a problem on wasm where the bevy_platform usage gets in the way of compilation.

Let me know if this breaks another use case! this was very much just me trying to get something to work on my machine.