### PR TITLE
clear previous selection on focus change

### DIFF
--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -5,8 +5,8 @@ use bevy::{
     prelude::*,
 };
 use bevy_ui_text_input::{
-    TextInputQueue, TextInputBuffer, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
-    TextInputStyle, TextSubmitEvent, actions::TextInputAction,
+    TextInputBuffer, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
+    TextInputQueue, TextInputStyle, TextSubmitEvent, actions::TextInputAction,
 };
 
 fn main() {

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -76,6 +76,7 @@ pub enum TextInputEdit {
     Undo,
     Redo,
     SelectAll,
+    SetSelection(Selection),
 }
 
 /// apply a single `TextInputEdit` to a text editor buffer
@@ -165,6 +166,9 @@ pub fn apply_text_input_edit(
         }
         TextInputEdit::Enter => {
             editor.action(Action::Enter);
+        }
+        TextInputEdit::SetSelection(selection) => {
+            editor.set_selection(selection);
         }
     }
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -48,7 +48,7 @@ pub struct Clipboard(Option<arboard::Clipboard>);
 #[cfg(unix)]
 impl Default for Clipboard {
     fn default() -> Self {
-        { Self(arboard::Clipboard::new().ok()) }
+        Self(arboard::Clipboard::new().ok())
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -16,6 +16,7 @@ use bevy::ecs::event::EventReader;
 use bevy::ecs::event::EventWriter;
 use bevy::ecs::observer::Trigger;
 use bevy::ecs::system::Commands;
+use bevy::ecs::system::Local;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
@@ -639,5 +640,22 @@ pub fn on_focused_keyboard_input(
                 queue.add(action);
             },
         );
+    }
+}
+
+pub fn clear_selection_on_focus_change(
+    input_focus: Res<InputFocus>,
+    mut previous_input_focus: Local<Option<Entity>>,
+    mut text_input_queues: Query<&mut TextInputQueue>,
+) {
+    if *previous_input_focus != input_focus.0 {
+        if let Some(entity) = *previous_input_focus {
+            if let Ok(mut text_input_queue) = text_input_queues.get_mut(entity) {
+                text_input_queue.add(TextInputAction::Edit(TextInputEdit::SetSelection(
+                    Selection::None,
+                )));
+            }
+        }
+        *previous_input_focus = input_focus.0;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ use bevy::text::{GlyphAtlasInfo, TextFont};
 use bevy::text::{JustifyText, TextColor};
 use bevy::ui::{Node, RenderUiSystem, UiSystem, extract_text_sections};
 use edit::{
-    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    clear_selection_on_focus_change, cursor_blink_system, mouse_wheel_scroll, on_drag_text_input,
+    on_focused_keyboard_input, on_move_clear_multi_click, on_multi_click_set_selection,
+    on_text_input_pressed, process_text_input_queues,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -63,6 +63,7 @@ impl Plugin for TextInputPlugin {
                         update_text_input_contents,
                         text_input_system,
                         text_input_prompt_system,
+                        clear_selection_on_focus_change,
                     )
                         .chain()
                         .in_set(UiSystem::PostLayout),


### PR DESCRIPTION
just bringing back the selection clearing behavior i introduced here https://github.com/ickshonpe/bevy_ui_text_input/pull/2 which got removed at some point (was that intentional?), ported to using the action queue with a new `TextInputEdit::SetSelection` variant

tested using the multiple inputs example

also run `cargo fmt` and fixed a clippy issue