### PR TITLE
minor cursor changes + clippy fix

### DIFF
--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -5,8 +5,8 @@ use bevy::{
     prelude::*,
 };
 use bevy_ui_text_input::{
-    TextInputQueue, TextInputBuffer, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
-    TextInputStyle, TextSubmitEvent, actions::TextInputAction,
+    TextInputBuffer, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
+    TextInputQueue, TextInputStyle, TextSubmitEvent, actions::TextInputAction,
 };
 
 fn main() {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -48,7 +48,7 @@ pub struct Clipboard(Option<arboard::Clipboard>);
 #[cfg(unix)]
 impl Default for Clipboard {
     fn default() -> Self {
-        { Self(arboard::Clipboard::new().ok()) }
+        Self(arboard::Clipboard::new().ok())
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -192,6 +192,8 @@ pub(crate) fn on_text_input_pressed(
         x: position.x as i32 + scroll.horizontal as i32,
         y: position.y as i32,
     });
+
+    buffer.cursor_blink_time = 0.0;
 }
 
 /// Updates the scroll position of scrollable nodes in response to mouse input

--- a/src/render.rs
+++ b/src/render.rs
@@ -146,17 +146,18 @@ pub fn extract_text_input_nodes(
             });
         }
 
+        let selection = input_buffer.editor.selection_bounds();
+
         let cursor_visable = active_text_input.0.is_some_and(|active| active == entity)
             && input.is_enabled
             && input_buffer.cursor_blink_time < style.blink_interval
-            && !style.cursor_color.is_fully_transparent();
+            && !style.cursor_color.is_fully_transparent()
+            && selection.is_none();
 
         let cursor_position = input_buffer
             .editor
             .cursor_position()
             .filter(|_| cursor_visable);
-
-        let selection = input_buffer.editor.selection_bounds();
 
         for TextInputGlyph {
             position,


### PR DESCRIPTION
- stops blinking cursor when there's a selection
- resets cursor blink timer on pressed
- fixes an extra braces lint
- ran `cargo fmt`