### PR TITLE
IME support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ use bevy::text::{GlyphAtlasInfo, TextFont};
 use bevy::text::{JustifyText, TextColor};
 use bevy::ui::{Node, RenderUiSystem, UiSystem, extract_text_sections};
 use edit::{
-    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    cursor_blink_system, listen_ime_events, mouse_wheel_scroll, on_drag_text_input,
+    on_focused_keyboard_input, on_move_clear_multi_click, on_multi_click_set_selection,
+    on_text_input_pressed, process_text_input_queues, toggle_ime_on_focus,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -57,6 +57,7 @@ impl Plugin for TextInputPlugin {
                 (
                     remove_dropped_font_atlas_sets_from_text_input_pipeline.before(AssetEvents),
                     (
+                        toggle_ime_on_focus,
                         cursor_blink_system,
                         mouse_wheel_scroll,
                         process_text_input_queues,
@@ -142,6 +143,7 @@ fn on_add_textinputnode(mut world: DeferredWorld, context: HookContext) {
         Observer::new(on_multi_click_set_selection),
         Observer::new(on_move_clear_multi_click),
         Observer::new(on_focused_keyboard_input),
+        Observer::new(listen_ime_events),
     ] {
         observer.watch_entity(context.entity);
         world.commands().spawn(observer);


### PR DESCRIPTION
Hello, this PR adds basic IME support.

What is supported :

* Enable/disable window IME (through winit) if a TextInputNode has focus
* Listen for IME commit events and convert them to TextInputEdit.

I tested this PR on iOS 18.4 (real device).