### PR TITLE
Implement `TextInputFilter` so we can remove `regex` and `once_cell` dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ repository = "https://github.com/ickshonpe/bevy_ui_text_input"
 [dependencies]
 bevy = { version = "0.16", features = ["bevy_asset", "bevy_ui"] }
 sys-locale = "0.3.0"
-regex = "1.11.1"
-once_cell = "1.21.3"
 cosmic_undo_2 = "0.2.0"
 
 [target.'cfg(any(windows, unix))'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,6 @@ use edit::{
     on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
     process_text_input_queues,
 };
-use once_cell::sync::Lazy;
-use regex::Regex;
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
     TextInputPipeline, remove_dropped_font_atlas_sets_from_text_input_pipeline,
@@ -190,23 +188,14 @@ pub enum TextInputFilter {
     Hex,
 }
 
-static INTEGER_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d+$").unwrap());
-static DECIMAL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap());
 
 impl TextInputFilter {
-    pub fn regex(&self) -> Option<&regex::Regex> {
-        match self {
-            TextInputFilter::Integer => Some(&INTEGER_REGEX),
-            TextInputFilter::Decimal => Some(&DECIMAL_REGEX),
-            TextInputFilter::Hex => None,
-        }
-    }
-
+    /// Checks if it is a valid digit, besides for the potential '-' sign.
     fn is_match_char(&self, ch: char) -> bool {
         match self {
             TextInputFilter::Integer => {
                 // Allow only numeric characters
-                ch.is_ascii_digit() || ch == '-'
+                ch.is_ascii_digit()
             }
             TextInputFilter::Hex => {
                 // Allow hexadecimal characters (0-9, a-f, A-F)
@@ -214,19 +203,92 @@ impl TextInputFilter {
             }
             TextInputFilter::Decimal => {
                 // Allow numeric characters and a single decimal point
-                ch.is_ascii_digit() || ch == '.' || ch == '-'
+                ch.is_ascii_digit() || ch == '.'
             }
         }
     }
 
-    fn is_match(self, text: &str) -> bool {
-        if let Some(regex) = self.regex() {
-            // If a regex is defined, use it to validate the entire text
-            regex.is_match(text)
-        } else {
-            // Otherwise, check each character against the filter
-            text.chars().all(|ch| self.is_match_char(ch))
+    /// Returns true if the input matches the filter.
+    /// Empty strings will pass the filters.
+    pub fn is_match(self, text: &str) -> bool {
+        match self {
+            TextInputFilter::Integer => {
+                let mut chars = text.chars();
+
+                // discard leading minus sign
+                if text.starts_with("-") {
+                    chars.next();
+                }
+
+                // ensure the rest are valid
+                chars.all(|ch| self.is_match_char(ch))
+            },
+            TextInputFilter::Hex => {
+                // check each character against the filter
+                text.chars().all(|ch| self.is_match_char(ch))
+            },
+            TextInputFilter::Decimal => {
+                let mut chars = text.chars();
+
+                // discard leading minus sign
+                if text.starts_with("-") {
+                    chars.next();
+                }
+
+                // we only have 1 period
+                let period_count = text.matches('.').count();
+
+                // ensure the rest are valid
+                // Otherwise, check each character against the filter
+                period_count <= 1 && chars.all(|ch| self.is_match_char(ch))
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_match_integer() {
+        assert!(TextInputFilter::Integer.is_match(""));
+        assert!(TextInputFilter::Integer.is_match("-"));
+        assert!(TextInputFilter::Integer.is_match("-1"));
+        assert!(TextInputFilter::Integer.is_match("-11919"));
+        assert!(TextInputFilter::Integer.is_match("11919"));
+        assert!(TextInputFilter::Integer.is_match("1"));
+        assert!(!TextInputFilter::Integer.is_match("1-"));
+        assert!(!TextInputFilter::Integer.is_match("--1"));
+        assert!(!TextInputFilter::Integer.is_match("-11-1"));
+    }
+
+    #[test]
+    fn is_match_digit() {
+        assert!(TextInputFilter::Decimal.is_match(""));
+        assert!(TextInputFilter::Decimal.is_match("-"));
+        assert!(TextInputFilter::Decimal.is_match("-1"));
+        assert!(TextInputFilter::Decimal.is_match("-11919"));
+        assert!(TextInputFilter::Decimal.is_match("11919"));
+        assert!(TextInputFilter::Decimal.is_match("1"));
+        assert!(!TextInputFilter::Decimal.is_match("1-"));
+        assert!(!TextInputFilter::Decimal.is_match("--1"));
+        assert!(!TextInputFilter::Decimal.is_match("-11-1"));
+        assert!(!TextInputFilter::Decimal.is_match(".."));
+        assert!(!TextInputFilter::Decimal.is_match("-.."));
+        assert!(!TextInputFilter::Decimal.is_match("1.."));
+        assert!(TextInputFilter::Decimal.is_match("."));
+        assert!(TextInputFilter::Decimal.is_match("-."));
+        assert!(TextInputFilter::Decimal.is_match("-1."));
+        assert!(TextInputFilter::Decimal.is_match("-.1"));
+        assert!(TextInputFilter::Decimal.is_match("-.11919"));
+        assert!(TextInputFilter::Decimal.is_match("-119.19"));
+        assert!(TextInputFilter::Decimal.is_match("-119."));
+        assert!(TextInputFilter::Decimal.is_match("11919"));
+        assert!(TextInputFilter::Decimal.is_match("1"));
+        assert!(!TextInputFilter::Decimal.is_match("1-"));
+        assert!(!TextInputFilter::Decimal.is_match("--1"));
+        assert!(!TextInputFilter::Decimal.is_match("-11-1"));
     }
 }
 


### PR DESCRIPTION
We don't need regex to match a simple pattern, just implement it.

I removed the regex and once_cell dependencies by implementing the text filter.

This will technically break public API as `TextInputFilter::regex` is removed, yet I don't think anyone would be using it.
If that is a problem, we could add a feature to re-enable it, but I think that would be unnecessary.

I also added tests for the filters.

Just tell me if you want me to change anything and I can go ahead and do it.