### PR TITLE
Changed TextInputFilter from enum to closure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/ickshonpe/bevy_ui_text_input"
 bevy = { version = "0.16", features = ["bevy_asset", "bevy_ui"] }
 sys-locale = "0.3.0"
 regex = "1.11.1"
-once_cell = "1.21.3"
 cosmic_undo_2 = "0.2.0"
 
 [target.'cfg(any(windows, unix))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ sys-locale = "0.3.0"
 regex = "1.11.1"
 cosmic_undo_2 = "0.2.0"
 
+[dev-dependencies]
+once_cell = "1.21.3"
+
 [target.'cfg(any(windows, unix))'.dependencies]
 arboard = { version = "3.5.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/ickshonpe/bevy_ui_text_input"
 [dependencies]
 bevy = { version = "0.16", features = ["bevy_asset", "bevy_ui"] }
 sys-locale = "0.3.0"
-regex = "1.11.1"
 cosmic_undo_2 = "0.2.0"
 
 [dev-dependencies]
 once_cell = "1.21.3"
+regex = "1.11.1"
 
 [target.'cfg(any(windows, unix))'.dependencies]
 arboard = { version = "3.5.0", default-features = false }

--- a/examples/decimal.rs
+++ b/examples/decimal.rs
@@ -4,6 +4,10 @@ use bevy::{color::palettes::css::NAVY, input_focus::InputFocus, prelude::*};
 use bevy_ui_text_input::{
     TextInputMode, TextInputNode, TextInputPlugin, TextSubmitEvent,
 };
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static FILTER_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap());
 
 fn main() {
     App::new()
@@ -21,7 +25,7 @@ fn setup(mut commands: Commands, mut active_input: ResMut<InputFocus>) {
         .spawn((
             TextInputNode {
                 mode: TextInputMode::SingleLine,
-                filter: Some(regex::Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap()),
+                filter: Some(&*FILTER_REGEX),
                 max_chars: Some(10),
                 ..Default::default()
             },

--- a/examples/decimal.rs
+++ b/examples/decimal.rs
@@ -2,7 +2,7 @@
 
 use bevy::{color::palettes::css::NAVY, input_focus::InputFocus, prelude::*};
 use bevy_ui_text_input::{
-    TextInputFilter, TextInputMode, TextInputNode, TextInputPlugin, TextSubmitEvent,
+    TextInputMode, TextInputNode, TextInputPlugin, TextSubmitEvent,
 };
 
 fn main() {
@@ -21,7 +21,7 @@ fn setup(mut commands: Commands, mut active_input: ResMut<InputFocus>) {
         .spawn((
             TextInputNode {
                 mode: TextInputMode::SingleLine,
-                filter: Some(TextInputFilter::Decimal),
+                filter: Some(regex::Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap()),
                 max_chars: Some(10),
                 ..Default::default()
             },

--- a/examples/decimal.rs
+++ b/examples/decimal.rs
@@ -25,7 +25,7 @@ fn setup(mut commands: Commands, mut active_input: ResMut<InputFocus>) {
         .spawn((
             TextInputNode {
                 mode: TextInputMode::SingleLine,
-                filter: Some(&*FILTER_REGEX),
+                filter: Some(Box::new(|text| FILTER_REGEX.is_match(text))),
                 max_chars: Some(10),
                 ..Default::default()
             },

--- a/examples/multiple_inputs.rs
+++ b/examples/multiple_inputs.rs
@@ -7,7 +7,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_ui_text_input::{
-    TextInputFilter, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
+    TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
     TextSubmitEvent,
 };
 
@@ -30,9 +30,9 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
 
     let filters = [
         (None, "text"),
-        (Some(TextInputFilter::Integer), "integer"),
-        (Some(TextInputFilter::Decimal), "decimal"),
-        (Some(TextInputFilter::Hex), "hex"),
+        (Some(regex::Regex::new(r"^-?$|^-?\d+$").unwrap()), "integer"),
+        (Some(regex::Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap()), "decimal"),
+        (Some(regex::Regex::new(r"^[a-fA-F\d]*$").unwrap()), "hex")
     ];
 
     commands

--- a/examples/multiple_inputs.rs
+++ b/examples/multiple_inputs.rs
@@ -7,8 +7,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_ui_text_input::{
-    TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
-    TextSubmitEvent,
+    TextInputFilter, TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt, TextSubmitEvent
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -34,11 +33,11 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
 
     let mut map = InputMap::default();
 
-    let filters = [
+    let filters: [(Option<Box<dyn TextInputFilter>>, &str); 4] = [
         (None, "text"),
-        (Some(&*DECIMAL_REGEX), "integer"),
-        (Some(&*NUMBER_REGEX), "decimal"),
-        (Some(&*HEX_REGEX), "hex")
+        (Some(Box::new(|text| DECIMAL_REGEX.is_match(text))), "integer"),
+        (Some(Box::new(|text| NUMBER_REGEX.is_match(text))), "decimal"),
+        (Some(Box::new(|text| HEX_REGEX.is_match(text))), "hex")
     ];
 
     commands

--- a/examples/multiple_inputs.rs
+++ b/examples/multiple_inputs.rs
@@ -10,6 +10,12 @@ use bevy_ui_text_input::{
     TextInputMode, TextInputNode, TextInputPlugin, TextInputPrompt,
     TextSubmitEvent,
 };
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static DECIMAL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap());
+static NUMBER_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d+$").unwrap());
+static HEX_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-fA-F\d]*$").unwrap());
 
 fn main() {
     App::new()
@@ -30,9 +36,9 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>) {
 
     let filters = [
         (None, "text"),
-        (Some(regex::Regex::new(r"^-?$|^-?\d+$").unwrap()), "integer"),
-        (Some(regex::Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap()), "decimal"),
-        (Some(regex::Regex::new(r"^[a-fA-F\d]*$").unwrap()), "hex")
+        (Some(&*DECIMAL_REGEX), "integer"),
+        (Some(&*NUMBER_REGEX), "decimal"),
+        (Some(&*HEX_REGEX), "hex")
     ];
 
     commands

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -2,6 +2,10 @@
 
 use bevy::{color::palettes::css::NAVY, prelude::*};
 use bevy_ui_text_input::{TextInputMode, TextInputNode, TextInputPlugin};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static FILTER_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d+$").unwrap());
 
 fn main() {
     App::new()
@@ -18,7 +22,7 @@ fn setup(mut commands: Commands) {
         .spawn((
             TextInputNode {
                 mode: TextInputMode::SingleLine,
-                filter: Some(regex::Regex::new(r"^-?$|^-?\d+$").unwrap()),
+                filter: Some(&*FILTER_REGEX),
                 max_chars: Some(5),
                 ..Default::default()
             },

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -22,7 +22,7 @@ fn setup(mut commands: Commands) {
         .spawn((
             TextInputNode {
                 mode: TextInputMode::SingleLine,
-                filter: Some(&*FILTER_REGEX),
+                filter: Some(Box::new(|text| FILTER_REGEX.is_match(text))),
                 max_chars: Some(5),
                 ..Default::default()
             },

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -1,7 +1,7 @@
 //! minimal text input example
 
 use bevy::{color::palettes::css::NAVY, prelude::*};
-use bevy_ui_text_input::{TextInputFilter, TextInputMode, TextInputNode, TextInputPlugin};
+use bevy_ui_text_input::{TextInputMode, TextInputNode, TextInputPlugin};
 
 fn main() {
     App::new()
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands) {
         .spawn((
             TextInputNode {
                 mode: TextInputMode::SingleLine,
-                filter: Some(TextInputFilter::Integer),
+                filter: Some(regex::Regex::new(r"^-?$|^-?\d+$").unwrap()),
                 max_chars: Some(5),
                 ..Default::default()
             },

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -10,6 +10,7 @@ use crate::edit::apply_action;
 use crate::edit::apply_motion;
 use crate::edit::buffer_len;
 use crate::edit::cursor_at_line_end;
+use crate::TextInputFilter;
 
 /// Actions that can be recieved by a text input
 #[derive(Debug)]
@@ -83,7 +84,7 @@ pub fn apply_text_input_edit(
     editor: &mut BorrowedWithFontSystem<'_, Editor<'static>>,
     changes: &mut cosmic_undo_2::Commands<bevy::text::cosmic_text::Change>,
     max_chars: Option<usize>,
-    filter_mode: &Option<&'static regex::Regex>,
+    filter_mode: Option<&mut dyn TextInputFilter>
 ) {
     editor.start_change();
 
@@ -177,7 +178,7 @@ pub fn apply_text_input_edit(
 
     if let Some(filter_mode) = filter_mode {
         let text = editor.with_buffer(crate::get_text);
-        if !filter_mode.is_match(&text) {
+        if !filter_mode(text.as_str()) {
             change.reverse();
             editor.apply_change(&change);
             return;

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -5,7 +5,6 @@ use bevy::text::cosmic_text::Editor;
 use bevy::text::cosmic_text::Motion;
 use bevy::text::cosmic_text::Selection;
 
-use crate::TextInputFilter;
 use crate::clipboard::ClipboardRead;
 use crate::edit::apply_action;
 use crate::edit::apply_motion;
@@ -84,7 +83,7 @@ pub fn apply_text_input_edit(
     editor: &mut BorrowedWithFontSystem<'_, Editor<'static>>,
     changes: &mut cosmic_undo_2::Commands<bevy::text::cosmic_text::Change>,
     max_chars: Option<usize>,
-    filter_mode: &Option<TextInputFilter>,
+    filter_mode: &Option<regex::Regex>,
 ) {
     editor.start_change();
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -83,7 +83,7 @@ pub fn apply_text_input_edit(
     editor: &mut BorrowedWithFontSystem<'_, Editor<'static>>,
     changes: &mut cosmic_undo_2::Commands<bevy::text::cosmic_text::Change>,
     max_chars: Option<usize>,
-    filter_mode: &Option<regex::Regex>,
+    filter_mode: &Option<&'static regex::Regex>,
 ) {
     editor.start_change();
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -48,7 +48,7 @@ pub struct Clipboard(Option<arboard::Clipboard>);
 #[cfg(unix)]
 impl Default for Clipboard {
     fn default() -> Self {
-        { Self(arboard::Clipboard::new().ok()) }
+        Self(arboard::Clipboard::new().ok())
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -542,7 +542,7 @@ pub fn cursor_blink_system(
 pub fn process_text_input_queues(
     mut query: Query<(
         Entity,
-        &TextInputNode,
+        &mut TextInputNode,
         &mut TextInputBuffer,
         &mut TextInputQueue,
     )>,
@@ -552,7 +552,7 @@ pub fn process_text_input_queues(
 ) {
     let mut font_system = &mut text_input_pipeline.font_system;
 
-    for (entity, node, mut buffer, mut actions_queue) in query.iter_mut() {
+    for (entity, mut node, mut buffer, mut actions_queue) in query.iter_mut() {
         let TextInputBuffer {
             editor, changes, ..
         } = &mut *buffer;
@@ -575,7 +575,7 @@ pub fn process_text_input_queues(
                             &mut editor,
                             changes,
                             node.max_chars,
-                            &node.filter,
+                            node.filter.as_deref_mut(),
                         );
                     }
                 }
@@ -595,7 +595,7 @@ pub fn process_text_input_queues(
                                 &mut editor,
                                 changes,
                                 node.max_chars,
-                                &node.filter,
+                                node.filter.as_deref_mut(),
                             );
                         }
                     } else {
@@ -610,7 +610,7 @@ pub fn process_text_input_queues(
                         &mut editor,
                         changes,
                         node.max_chars,
-                        &node.filter,
+                        node.filter.as_deref_mut(),
                     );
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ use edit::{
     on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
     process_text_input_queues,
 };
-use once_cell::sync::Lazy;
 use regex::Regex;
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -104,7 +103,7 @@ pub struct TextInputNode {
     /// Type of text input
     pub mode: TextInputMode,
     /// Optional filter for the text input
-    pub filter: Option<TextInputFilter>,
+    pub filter: Option<Regex>,
     /// Maximum number of characters that can entered into the input buffer
     pub max_chars: Option<usize>,
     /// Should overwrite mode be available
@@ -174,60 +173,6 @@ pub enum TextInputMode {
     /// Scrolls horizontally
     /// Submit on enter
     SingleLine,
-}
-
-/// Filter for text input
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum TextInputFilter {
-    /// Integer input
-    /// accepts only digits and a leading sign
-    Integer,
-    /// Decimal input
-    /// accepts only digits, a decimal point and a leading sign
-    Decimal,
-    /// Hexadecimal input
-    /// accepts only `0-9`, `a-f` and `A-F`
-    Hex,
-}
-
-static INTEGER_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d+$").unwrap());
-static DECIMAL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?$|^-?\d*\.?\d*$").unwrap());
-
-impl TextInputFilter {
-    pub fn regex(&self) -> Option<&regex::Regex> {
-        match self {
-            TextInputFilter::Integer => Some(&INTEGER_REGEX),
-            TextInputFilter::Decimal => Some(&DECIMAL_REGEX),
-            TextInputFilter::Hex => None,
-        }
-    }
-
-    fn is_match_char(&self, ch: char) -> bool {
-        match self {
-            TextInputFilter::Integer => {
-                // Allow only numeric characters
-                ch.is_ascii_digit() || ch == '-'
-            }
-            TextInputFilter::Hex => {
-                // Allow hexadecimal characters (0-9, a-f, A-F)
-                ch.is_ascii_hexdigit()
-            }
-            TextInputFilter::Decimal => {
-                // Allow numeric characters and a single decimal point
-                ch.is_ascii_digit() || ch == '.' || ch == '-'
-            }
-        }
-    }
-
-    fn is_match(self, text: &str) -> bool {
-        if let Some(regex) = self.regex() {
-            // If a regex is defined, use it to validate the entire text
-            regex.is_match(text)
-        } else {
-            // Otherwise, check each character against the filter
-            text.chars().all(|ch| self.is_match_char(ch))
-        }
-    }
 }
 
 impl Default for TextInputMode {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ use edit::{
     on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
     process_text_input_queues,
 };
-use regex::Regex;
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
     TextInputPipeline, remove_dropped_font_atlas_sets_from_text_input_pipeline,
@@ -82,6 +81,14 @@ impl Plugin for TextInputPlugin {
     }
 }
 
+pub trait TextInputFilter: FnMut(&str) -> bool + Send + Sync + 'static {}
+impl<T> TextInputFilter for T where T: FnMut(&str) -> bool + Send + Sync + 'static {}
+impl std::fmt::Debug for dyn TextInputFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+         f.write_str("TextInputFilter closure")
+    }
+}
+
 #[derive(Component, Debug)]
 #[require(
     Node,
@@ -103,7 +110,7 @@ pub struct TextInputNode {
     /// Type of text input
     pub mode: TextInputMode,
     /// Optional filter for the text input
-    pub filter: Option<&'static Regex>,
+    pub filter: Option<Box<dyn TextInputFilter>>,
     /// Maximum number of characters that can entered into the input buffer
     pub max_chars: Option<usize>,
     /// Should overwrite mode be available

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub struct TextInputNode {
     /// Type of text input
     pub mode: TextInputMode,
     /// Optional filter for the text input
-    pub filter: Option<Regex>,
+    pub filter: Option<&'static Regex>,
     /// Maximum number of characters that can entered into the input buffer
     pub max_chars: Option<usize>,
     /// Should overwrite mode be available


### PR DESCRIPTION
This PR introduces a breaking change to the library.

TextInputFilter is limited to 3 pre-defined filters. The switch to directly using regex allows implementer to specify a custom filter.

You could add a TextInputFilter::Custom(Regex) variant in the TextInputFilter enum as a non-breaking change, but then it just becomes a regex wrapper with 3 pre-defined regexes, and it has more overhead due to pattern matching at runtime. It would be better to have const or static variables for pre-defined filters.

However, I removed the lazy-static regexes for integer, decimal, and hex because I think it's better to let the implementer decide which regexes they want to use. Getting rid of them also removes the once-cell dependency and the marginal cost of having static variables that you might not use.

The library and all modified examples were built locally with no errors.

Edit: Instead of forcing a regex, I've changed it to a closure for better generalization.