### PR TITLE
Adding has_selection helper to TextInputBuffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use bevy::text::{GlyphAtlasInfo, TextFont};
 use bevy::text::{Justify, TextColor};
 use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
-use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
+use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Selection, Wrap};
 use edit::{
     cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
     on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
@@ -280,6 +280,10 @@ pub struct TextInputBuffer {
 impl TextInputBuffer {
     pub fn get_text(&self) -> String {
         self.editor.with_buffer(get_text)
+    }
+
+    pub fn has_selection(&self) -> bool {
+        self.editor.selection() != Selection::None
     }
 }
 


### PR DESCRIPTION
It's handy to be able to be able to check if a TextInputBuffer has a current selection without having to pull in cosmic_text yourself and go through the editor.

My use case is that I'm writing a custom debug console and want to be able to press Esc to quickly clear the input, unless I have something selected, in which case I want Esc to deselect as normal first.