### PR TITLE
Update to Bevy 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.7.0
+
+* Bevy 0.18 support.
+
 ### 0.6.0
 
 * Bevy 0.17 support.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,14 @@ name = "bevy_ui_text_input"
 keywords = ["bevy", "gamedev", "ui", "text", "input"]
 description = "Bevy UI text input plugin"
 categories = ["game-development", "gui", "text-editors"]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/ickshonpe/bevy_ui_text_input"
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_asset",
     "bevy_ui",
     "bevy_input_focus",
@@ -21,7 +21,7 @@ sys-locale = "0.3.2"
 once_cell = "1.21.3"
 cosmic_undo_2 = "0.2.0"
 # Keep in sync with https://github.com/bevyengine/bevy/blob/main/crates/bevy_text/Cargo.toml#L33
-cosmic-text = "0.14"
+cosmic-text = "0.16"
 
 [target.'cfg(any(windows, unix))'.dependencies]
 arboard = { version = "3.6.1", default-features = false }
@@ -46,4 +46,4 @@ codegen-units = 4
 opt-level = 0
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"

--- a/README.md
+++ b/README.md
@@ -60,5 +60,6 @@ cargo run --example text_input
 
 | Bevy      | bevy_ui_text_input |
 |-----------|--------------------|
+| 0.18      | 0.7                |
 | 0.17      | 0.6                |
 | 0.16      | 0.5                |

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -138,7 +138,10 @@ pub fn apply_text_input_edit(
             editor.action(Action::Drag { x, y });
         }
         TextInputEdit::Scroll { lines } => {
-            editor.action(Action::Scroll { lines });
+            let line_height = editor.with_buffer(|buffer| buffer.metrics().line_height);
+            editor.action(Action::Scroll {
+                pixels: lines as f32 * line_height,
+            });
         }
         TextInputEdit::Paste(text) => {
             if max_chars.is_none_or(|max| editor.with_buffer(buffer_len) + text.len() <= max) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl Plugin for TextInputPlugin {
     TextInputStyle,
     TextColor,
     TextInputQueue,
-    LineHeight,
+    LineHeight
 )]
 #[component(
     on_add = on_add_textinputnode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use bevy::math::{Rect, Vec2};
 use bevy::prelude::ReflectComponent;
 use bevy::reflect::{Reflect, std_traits::ReflectDefault};
 use bevy::render::{ExtractSchedule, RenderApp};
-use bevy::text::{GlyphAtlasInfo, TextFont};
+use bevy::text::{GlyphAtlasInfo, LineHeight, TextFont};
 use bevy::text::{Justify, TextColor};
 use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
@@ -92,7 +92,8 @@ impl Plugin for TextInputPlugin {
     TextInputLayoutInfo,
     TextInputStyle,
     TextColor,
-    TextInputQueue
+    TextInputQueue,
+    LineHeight,
 )]
 #[component(
     on_add = on_add_textinputnode,


### PR DESCRIPTION
Updated to Bevy 0.18.

Tested very briefly by playing around with the text_input example, and saw no obvious change in behaviour.

I believe the only user-facing change is that `LineHeight` is now required by `TextInputNode`, but as moving line height out is a change from bevy, I don't think it necessitates a mention in the change log.