### PR TITLE
feat: add IME (Input Method Editor) support

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -27,6 +27,10 @@ pub enum TextInputAction {
     PasteDeferred(ClipboardRead),
     /// A single edit action
     Edit(TextInputEdit),
+    /// IME preedit (composition) update
+    ImePreedit { value: String },
+    /// IME commit (finalized text)
+    ImeCommit { value: String },
 }
 
 /// An edit to perform on a [`TextInputBuffer`](crate::TextInputBuffer)

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -2,6 +2,7 @@ use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
 use crate::TextInputGlobalState;
+use crate::TextInputImeState;
 use crate::TextInputMode;
 use crate::TextInputNode;
 use crate::TextInputQueue;
@@ -16,6 +17,7 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::message::MessageReader;
 use bevy::ecs::message::MessageWriter;
 use bevy::ecs::observer::On;
+use bevy::ecs::query::With;
 use bevy::ecs::system::Commands;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
@@ -28,6 +30,7 @@ use bevy::input::mouse::MouseWheel;
 use bevy::input_focus::FocusedInput;
 use bevy::input_focus::InputFocus;
 use bevy::math::Rect;
+use bevy::math::Vec2;
 use bevy::picking::events::Click;
 use bevy::picking::events::Drag;
 use bevy::picking::events::Move;
@@ -38,6 +41,7 @@ use bevy::picking::pointer::PointerButton;
 use bevy::time::Time;
 use bevy::ui::ComputedNode;
 use bevy::ui::UiGlobalTransform;
+use bevy::window::{Ime, Window};
 use cosmic_text::Action;
 use cosmic_text::BorrowedWithFontSystem;
 use cosmic_text::Change;
@@ -545,6 +549,7 @@ pub fn process_text_input_queues(
         &TextInputNode,
         &mut TextInputBuffer,
         &mut TextInputQueue,
+        &mut TextInputImeState,
         Option<&TextInputFilter>,
     )>,
     mut text_input_pipeline: ResMut<TextInputPipeline>,
@@ -553,7 +558,9 @@ pub fn process_text_input_queues(
 ) {
     let font_system = &mut text_input_pipeline.font_system;
 
-    for (entity, node, mut buffer, mut actions_queue, maybe_filter) in query.iter_mut() {
+    for (entity, node, mut buffer, mut actions_queue, mut ime_state, maybe_filter) in
+        query.iter_mut()
+    {
         let TextInputBuffer {
             editor, changes, ..
         } = &mut *buffer;
@@ -614,6 +621,47 @@ pub fn process_text_input_queues(
                         maybe_filter,
                     );
                 }
+                TextInputAction::ImePreedit { value } => {
+                    // Remove previous preedit text if any
+                    remove_preedit_text(&mut editor, &mut ime_state);
+
+                    if value.is_empty() {
+                        // Composition cancelled
+                        ime_state.preedit = None;
+                        ime_state.saved_cursor = None;
+                        ime_state.preedit_char_count = 0;
+                    } else {
+                        // Save cursor position before inserting preedit text
+                        let char_count = value.chars().count();
+                        let saved = editor.cursor();
+                        editor.insert_string(&value, None);
+
+                        ime_state.preedit = Some(value);
+                        ime_state.saved_cursor = Some(saved);
+                        ime_state.preedit_char_count = char_count;
+                    }
+                    editor.set_redraw(true);
+                }
+                TextInputAction::ImeCommit { value } => {
+                    // Remove preedit text first
+                    remove_preedit_text(&mut editor, &mut ime_state);
+
+                    // Insert committed text normally (with undo tracking, filter, max_chars)
+                    if !value.is_empty() {
+                        apply_text_input_edit(
+                            TextInputEdit::Paste(value),
+                            &mut editor,
+                            changes,
+                            node.max_chars,
+                            maybe_filter,
+                        );
+                    }
+
+                    // Clear IME state
+                    ime_state.preedit = None;
+                    ime_state.saved_cursor = None;
+                    ime_state.preedit_char_count = 0;
+                }
             }
         }
     }
@@ -621,10 +669,22 @@ pub fn process_text_input_queues(
 
 pub fn on_focused_keyboard_input(
     trigger: On<FocusedInput<KeyboardInput>>,
-    mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
+    mut query: Query<(&TextInputNode, &mut TextInputQueue, &TextInputImeState)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
-    if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
+    if let Ok((input, mut queue, ime_state)) = query.get_mut(trigger.focused_entity) {
+        // Suppress keyboard input while IME is composing — the IME handles these keys
+        if ime_state.preedit.is_some() {
+            let key = &trigger.event().input.logical_key;
+            if matches!(
+                key,
+                Key::Character(_) | Key::Space | Key::Backspace | Key::Delete | Key::Enter
+            ) && trigger.event().input.state.is_pressed()
+            {
+                return;
+            }
+        }
+
         let TextInputGlobalState {
             shift,
             overwrite_mode,
@@ -640,5 +700,125 @@ pub fn on_focused_keyboard_input(
                 queue.add(action);
             },
         );
+    }
+}
+
+/// Remove previously inserted preedit text from the editor using selection-based deletion.
+/// This is more robust than backspace-counting since it doesn't depend on cursor position.
+fn remove_preedit_text(
+    editor: &mut BorrowedWithFontSystem<Editor>,
+    ime_state: &mut TextInputImeState,
+) {
+    if ime_state.preedit_char_count > 0 {
+        if let Some(saved_cursor) = ime_state.saved_cursor {
+            // Select from saved cursor (before preedit) to current cursor (after preedit)
+            // The current cursor is at the end of the preedit text
+            let current_cursor = editor.cursor();
+            editor.set_cursor(saved_cursor);
+            editor.set_selection(Selection::Normal(current_cursor));
+            editor.delete_selection();
+        } else {
+            // Fallback: use backspace if we don't have a saved cursor
+            for _ in 0..ime_state.preedit_char_count {
+                editor.action(Action::Backspace);
+            }
+        }
+        ime_state.preedit_char_count = 0;
+        ime_state.saved_cursor = None;
+    }
+}
+
+/// Enables or disables IME on the window based on whether a text input is focused.
+/// Sets `ime_position` to just below the text cursor. The position is only updated
+/// when no preedit is active, so it stays fixed during composition.
+pub fn ime_focus_system(
+    input_focus: Res<InputFocus>,
+    text_input_query: Query<
+        (
+            &TextInputBuffer,
+            &ComputedNode,
+            &UiGlobalTransform,
+            &TextInputImeState,
+        ),
+        With<TextInputNode>,
+    >,
+    mut window_query: Query<&mut Window>,
+) {
+    if let Some(focused) = input_focus.0 {
+        if let Ok((buffer, node, transform, ime_state)) = text_input_query.get(focused) {
+            if let Some(mut window) = window_query.iter_mut().next() {
+                window.ime_enabled = true;
+                // Only update position when not composing, so the candidate
+                // box stays fixed once composition starts.
+                if ime_state.preedit.is_none() {
+                    if let Some((cx, cy)) = buffer.editor.cursor_position() {
+                        let rect = Rect::from_center_size(transform.translation, node.size());
+                        let line_height = buffer.editor.with_buffer(|b| b.metrics().line_height);
+                        window.ime_position = Vec2::new(
+                            rect.min.x + cx as f32,
+                            rect.min.y + cy as f32 + line_height * 0.8,
+                        );
+                    }
+                }
+            }
+            return;
+        }
+    }
+    // No text input focused — disable IME
+    for mut window in window_query.iter_mut() {
+        if window.ime_enabled {
+            window.ime_enabled = false;
+        }
+    }
+}
+
+/// Reads `Ime` messages and routes them to the focused text input's action queue.
+pub fn ime_event_system(
+    mut ime_reader: MessageReader<Ime>,
+    input_focus: Res<InputFocus>,
+    mut query: Query<&mut TextInputQueue, With<TextInputNode>>,
+) {
+    for ime in ime_reader.read() {
+        let Some(focused) = input_focus.0 else {
+            continue;
+        };
+        let Ok(mut queue) = query.get_mut(focused) else {
+            continue;
+        };
+        match ime {
+            Ime::Preedit { value, .. } => {
+                queue.add(TextInputAction::ImePreedit {
+                    value: value.clone(),
+                });
+            }
+            Ime::Commit { value, .. } => {
+                queue.add(TextInputAction::ImeCommit {
+                    value: value.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Cancels preedit text when the text input loses focus.
+pub fn ime_cleanup_on_unfocus_system(
+    input_focus: Res<InputFocus>,
+    mut query: Query<(Entity, &mut TextInputImeState, &mut TextInputBuffer), With<TextInputNode>>,
+    mut text_input_pipeline: ResMut<TextInputPipeline>,
+) {
+    for (entity, mut ime_state, mut buffer) in query.iter_mut() {
+        if ime_state.preedit.is_some() {
+            let is_focused = input_focus.0.is_some_and(|f| f == entity);
+            if !is_focused {
+                let mut editor = buffer
+                    .editor
+                    .borrow_with(&mut text_input_pipeline.font_system);
+                remove_preedit_text(&mut editor, &mut ime_state);
+                ime_state.preedit = None;
+                ime_state.saved_cursor = None;
+                ime_state.preedit_char_count = 0;
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
 use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
-    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    cursor_blink_system, ime_cleanup_on_unfocus_system, ime_event_system, ime_focus_system,
+    mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input, on_move_clear_multi_click,
+    on_multi_click_set_selection, on_text_input_pressed, process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -60,6 +60,9 @@ impl Plugin for TextInputPlugin {
                     (
                         cursor_blink_system,
                         mouse_wheel_scroll,
+                        ime_cleanup_on_unfocus_system,
+                        ime_focus_system,
+                        ime_event_system,
                         process_text_input_queues,
                         update_text_input_contents,
                         text_input_system,
@@ -93,7 +96,8 @@ impl Plugin for TextInputPlugin {
     TextInputStyle,
     TextColor,
     TextInputQueue,
-    LineHeight
+    LineHeight,
+    TextInputImeState
 )]
 #[component(
     on_add = on_add_textinputnode,
@@ -297,6 +301,18 @@ impl Default for TextInputBuffer {
     }
 }
 
+/// Tracks IME (Input Method Editor) composition state for a text input.
+#[derive(Component, Default, Debug)]
+pub struct TextInputImeState {
+    /// The current preedit (composing) text, if any.
+    pub preedit: Option<String>,
+    /// Saved cursor position from before preedit text was inserted.
+    /// Used for selection-based removal of preedit text.
+    pub(crate) saved_cursor: Option<cosmic_text::Cursor>,
+    /// Number of characters inserted as preedit (for removal).
+    pub preedit_char_count: usize,
+}
+
 /// Prompt displayed when the input is empty (including whitespace).
 /// Optional component.
 #[derive(Component, Clone, Debug, Reflect)]
@@ -350,6 +366,11 @@ pub struct TextInputStyle {
     pub cursor_height: f32,
     /// Time cursor blinks in seconds
     pub blink_interval: f32,
+    /// Color of the underline drawn beneath preedit (composing) text.
+    /// Defaults to `Color::NONE`, which follows the `TextColor`.
+    pub preedit_underline_color: Color,
+    /// Thickness of the preedit underline in logical pixels.
+    pub preedit_underline_thickness: f32,
 }
 
 impl Default for TextInputStyle {
@@ -362,6 +383,8 @@ impl Default for TextInputStyle {
             cursor_radius: 0.,
             cursor_height: 1.,
             blink_interval: 0.5,
+            preedit_underline_color: Color::NONE,
+            preedit_underline_thickness: 1.,
         }
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,6 @@
 use crate::TextInputBuffer;
 use crate::TextInputGlyph;
+use crate::TextInputImeState;
 use crate::TextInputLayoutInfo;
 use crate::TextInputNode;
 use crate::TextInputPrompt;
@@ -57,6 +58,7 @@ pub fn extract_text_input_nodes(
             &TextInputStyle,
             &TextInputNode,
             &TextInputBuffer,
+            &TextInputImeState,
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
@@ -78,6 +80,7 @@ pub fn extract_text_input_nodes(
         style,
         input,
         input_buffer,
+        ime_state,
     ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
@@ -209,6 +212,66 @@ pub fn extract_text_input_nodes(
 
             start = end;
             end += 1;
+        }
+
+        // Draw preedit underline beneath composing text
+        if ime_state.preedit.is_some() && ime_state.preedit_char_count > 0 {
+            let total_glyphs = text_layout_info.glyphs.len();
+            // Preedit glyphs are the last N glyphs (they were inserted at the cursor)
+            let preedit_start_idx = total_glyphs.saturating_sub(ime_state.preedit_char_count);
+            if preedit_start_idx < total_glyphs {
+                // Find the horizontal extent of preedit glyphs and the line index.
+                // Glyph position is center-based, so left edge = position.x - size.x * 0.5
+                let mut min_x = f32::MAX;
+                let mut max_x = f32::MIN;
+                let mut preedit_line_index = 0usize;
+                for glyph in &text_layout_info.glyphs[preedit_start_idx..] {
+                    let half_w = glyph.size.x * 0.5;
+                    min_x = min_x.min(glyph.position.x - half_w);
+                    max_x = max_x.max(glyph.position.x + half_w);
+                    preedit_line_index = glyph.line_index;
+                }
+                if min_x < max_x {
+                    // Use a consistent y based on line_height, not individual glyph bounds.
+                    let underline_y = (preedit_line_index + 1) as f32 * line_height;
+                    let underline_width = max_x - min_x;
+                    let underline_center_x = (min_x + max_x) * 0.5;
+                    let underline_center_y = underline_y + style.preedit_underline_thickness * 0.5;
+                    // Use dedicated preedit color if set, otherwise follow text color
+                    let underline_color =
+                        if style.preedit_underline_color != bevy::color::Color::NONE {
+                            LinearRgba::from(style.preedit_underline_color)
+                        } else {
+                            color
+                        };
+                    extracted_uinodes.uinodes.push(ExtractedUiNode {
+                        z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                        image: AssetId::default(),
+                        clip,
+                        extracted_camera_entity,
+                        transform: transform
+                            * Affine2::from_translation(Vec2::new(
+                                underline_center_x,
+                                underline_center_y,
+                            )),
+                        item: ExtractedUiItem::Node {
+                            color: underline_color,
+                            atlas_scaling: None,
+                            flip_x: false,
+                            flip_y: false,
+                            border_radius: ResolvedBorderRadius::ZERO,
+                            border: BorderRect::ZERO,
+                            node_type: NodeType::Rect,
+                            rect: Rect {
+                                min: Vec2::ZERO,
+                                max: Vec2::new(underline_width, style.preedit_underline_thickness),
+                            },
+                        },
+                        main_entity: entity.into(),
+                        render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    });
+                }
+            }
         }
 
         if let Some((x, y)) = cursor_position {


### PR DESCRIPTION
Add support for IME composition input (Chinese, Japanese, Korean, etc.):
![ime_show](https://github.com/user-attachments/assets/a890248f-4a14-45e8-b22a-13f9d0d35e0f)

- Add TextInputImeState component to track preedit composition state
- Add ImePreedit and ImeCommit action types
- Add ime_focus_system to enable/disable IME and position candidate box
- Add ime_event_system to route Bevy Ime messages to text inputs
- Add ime_cleanup_on_unfocus_system to cancel preedit on focus loss
- Suppress keyboard input during IME composition to prevent double input
- Render preedit underline beneath composing text (color follows TextColor by default, configurable via TextInputStyle)
- Use selection-based preedit removal for robustness