### PR TITLE
feat: add Android support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,17 @@ cosmic_undo_2 = "0.2.0"
 # Keep in sync with https://github.com/bevyengine/bevy/blob/main/crates/bevy_text/Cargo.toml#L33
 cosmic-text = "0.16"
 
-[target.'cfg(any(windows, unix))'.dependencies]
+[target.'cfg(all(any(windows, unix), not(target_os = "android")))'.dependencies]
 arboard = { version = "3.6.1", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", features = ["Navigator", "Clipboard"] }
 wasm-bindgen-futures = "0.4"
+
+[target.'cfg(target_os = "android")'.dependencies]
+bevy_android = "0.18"
+android-activity = { version = "0.6", features = ["game-activity"] }
 
 [lints.clippy]
 too_many_arguments = "allow"

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -27,6 +27,10 @@ pub enum TextInputAction {
     PasteDeferred(ClipboardRead),
     /// A single edit action
     Edit(TextInputEdit),
+    /// IME preedit (composition) update
+    ImePreedit { value: String },
+    /// IME commit (finalized text)
+    ImeCommit { value: String },
 }
 
 /// An edit to perform on a [`TextInputBuffer`](crate::TextInputBuffer)

--- a/src/android.rs
+++ b/src/android.rs
@@ -1,0 +1,124 @@
+use bevy::prelude::*;
+use bevy::input_focus::InputFocus;
+use bevy_android::ANDROID_APP;
+use android_activity::input::{TextInputState, TextSpan};
+use crate::{TextInputBuffer, TextInputGlobalState, TextInputNode, TextInputQueue};
+use crate::actions::{TextInputAction, TextInputEdit};
+
+#[cfg(target_os = "android")]
+pub fn android_text_input_poll_system(
+    focus: Res<InputFocus>,
+    mut global_state: ResMut<TextInputGlobalState>,
+    mut query: Query<&mut TextInputQueue, With<TextInputNode>>,
+) {
+    let Some(app) = ANDROID_APP.get() else { return; };
+    let Some(focused_entity) = focus.0 else { return; };
+
+    if let Ok(mut queue) = query.get_mut(focused_entity) {
+        let current_state = app.text_input_state();
+        
+        if current_state.text != global_state.last_android_text {
+            enqueue_text_diff(&global_state.last_android_text, &current_state.text, &mut queue);
+            global_state.last_android_text = current_state.text.clone();
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+pub fn android_text_input_sync_system(
+    focus: Res<InputFocus>,
+    mut global_state: ResMut<TextInputGlobalState>,
+    query: Query<(&TextInputBuffer, &TextInputQueue), (With<TextInputNode>, Changed<TextInputBuffer>)>,
+) {
+    let Some(app) = ANDROID_APP.get() else { return; };
+    let Some(focused_entity) = focus.0 else { return; };
+
+    if let Ok((buffer, queue)) = query.get(focused_entity) {
+        if !queue.is_empty() {
+            return;
+        }
+
+        let bevy_text = buffer.get_text();
+
+        if bevy_text != global_state.last_android_text {
+            let state = TextInputState {
+                text: bevy_text.clone(),
+                selection: TextSpan { start: bevy_text.len(), end: bevy_text.len() },
+                compose_region: None,
+            };
+            app.set_text_input_state(state);
+            global_state.last_android_text = bevy_text;
+        }
+    }
+}
+
+fn enqueue_text_diff(prev: &str, new: &str, queue: &mut TextInputQueue) {
+    let prev_chars: Vec<char> = prev.chars().collect();
+    let new_chars: Vec<char> = new.chars().collect();
+
+    let common_prefix = prev_chars
+        .iter()
+        .zip(new_chars.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let prev_tail = &prev_chars[common_prefix..];
+    let new_tail = &new_chars[common_prefix..];
+
+    let common_suffix = prev_tail
+        .iter()
+        .rev()
+        .zip(new_tail.iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let deletions = prev_tail.len() - common_suffix;
+    let insertions = &new_tail[..new_tail.len() - common_suffix];
+
+    for _ in 0..deletions {
+        if !queue.actions.iter().any(|a| matches!(a, TextInputAction::Edit(TextInputEdit::Backspace))) {
+             queue.add(TextInputAction::Edit(TextInputEdit::Backspace));
+        }
+    }
+
+    for &ch in insertions {
+        let is_problematic = ch.is_ascii_digit() || ch == ' ';
+        
+        if is_problematic {
+            let already_in_queue = queue.actions.iter().any(|a| {
+                if let TextInputAction::Edit(TextInputEdit::Insert(existing_ch, _)) = a {
+                    *existing_ch == ch
+                } else {
+                    false
+                }
+            });
+
+            if already_in_queue {
+                continue; 
+            }
+        }
+
+        queue.add(TextInputAction::Edit(TextInputEdit::Insert(ch, false)));
+    }
+}
+
+#[cfg(target_os = "android")]
+pub fn on_text_input_pressed_android(
+    trigger: On<Pointer<Press>>,
+    node_query: Query<&TextInputNode>,
+) {
+    if trigger.button != PointerButton::Primary {
+        return;
+    }
+
+    let Ok(input) = node_query.get(trigger.entity) else {
+        return;
+    };
+
+    if !input.is_enabled || !input.focus_on_pointer_down {
+        return;
+    }
+
+    let Some(app) = ANDROID_APP.get() else { return; };
+    app.show_soft_input(true);
+}

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -41,11 +41,11 @@ impl ClipboardRead {
 }
 
 /// Resource providing access to the clipboard
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "android")))]
 #[derive(Resource)]
 pub struct Clipboard(Option<arboard::Clipboard>);
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "android")))]
 impl Default for Clipboard {
     fn default() -> Self {
         Self(arboard::Clipboard::new().ok())
@@ -53,7 +53,7 @@ impl Default for Clipboard {
 }
 
 /// Resource providing access to the clipboard
-#[cfg(not(unix))]
+#[cfg(not(all(unix, not(target_os = "android"))))]
 #[derive(Resource, Default)]
 pub struct Clipboard;
 
@@ -62,7 +62,7 @@ impl Clipboard {
     ///
     /// On Windows and Unix `ClipboardRead`s are completed instantly, on wasm32 the result is fetched asynchronously.
     pub fn fetch_text(&mut self) -> ClipboardRead {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "android")))]
         {
             ClipboardRead::Ready(if let Some(clipboard) = self.0.as_mut() {
                 clipboard.get_text().map_err(ClipboardError::from)
@@ -99,7 +99,7 @@ impl Clipboard {
             }
         }
 
-        #[cfg(not(any(unix, windows, target_arch = "wasm32")))]
+        #[cfg(not(any(all(unix, not(target_os = "android")), windows, target_arch = "wasm32")))]
         {
             ClipboardRead::Ready(Err(ClipboardError::ClipboardNotSupported))
         }
@@ -112,9 +112,10 @@ impl Clipboard {
     /// Returns error if `text` failed to be stored on the clipboard.
     pub fn set_text<'a, T: Into<alloc::borrow::Cow<'a, str>>>(
         &mut self,
+        #[allow(unused_variables)]
         text: T,
     ) -> Result<(), ClipboardError> {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "android")))]
         {
             if let Some(clipboard) = self.0.as_mut() {
                 clipboard.set_text(text).map_err(ClipboardError::from)
@@ -143,7 +144,7 @@ impl Clipboard {
             }
         }
 
-        #[cfg(not(any(unix, windows, target_arch = "wasm32")))]
+        #[cfg(not(any(all(unix, not(target_os = "android")), windows, target_arch = "wasm32")))]
         {
             Err(ClipboardError::ClipboardNotSupported)
         }
@@ -176,7 +177,7 @@ pub enum ClipboardError {
     },
 }
 
-#[cfg(any(windows, unix))]
+#[cfg(any(windows, all(unix, not(target_os = "android"))))]
 impl From<arboard::Error> for ClipboardError {
     fn from(value: arboard::Error) -> Self {
         match value {

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -689,6 +689,7 @@ pub fn on_focused_keyboard_input(
             shift,
             overwrite_mode,
             command,
+            ..
         } = &mut *global_state;
         queue_text_input_action(
             &input.mode,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -2,6 +2,7 @@ use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
 use crate::TextInputGlobalState;
+use crate::TextInputImeState;
 use crate::TextInputMode;
 use crate::TextInputNode;
 use crate::TextInputQueue;
@@ -16,6 +17,7 @@ use bevy::ecs::entity::Entity;
 use bevy::ecs::message::MessageReader;
 use bevy::ecs::message::MessageWriter;
 use bevy::ecs::observer::On;
+use bevy::ecs::query::With;
 use bevy::ecs::system::Commands;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
@@ -28,6 +30,7 @@ use bevy::input::mouse::MouseWheel;
 use bevy::input_focus::FocusedInput;
 use bevy::input_focus::InputFocus;
 use bevy::math::Rect;
+use bevy::math::Vec2;
 use bevy::picking::events::Click;
 use bevy::picking::events::Drag;
 use bevy::picking::events::Move;
@@ -38,6 +41,7 @@ use bevy::picking::pointer::PointerButton;
 use bevy::time::Time;
 use bevy::ui::ComputedNode;
 use bevy::ui::UiGlobalTransform;
+use bevy::window::{Ime, Window};
 use cosmic_text::Action;
 use cosmic_text::BorrowedWithFontSystem;
 use cosmic_text::Change;
@@ -545,6 +549,7 @@ pub fn process_text_input_queues(
         &TextInputNode,
         &mut TextInputBuffer,
         &mut TextInputQueue,
+        &mut TextInputImeState,
         Option<&TextInputFilter>,
     )>,
     mut text_input_pipeline: ResMut<TextInputPipeline>,
@@ -553,7 +558,9 @@ pub fn process_text_input_queues(
 ) {
     let font_system = &mut text_input_pipeline.font_system;
 
-    for (entity, node, mut buffer, mut actions_queue, maybe_filter) in query.iter_mut() {
+    for (entity, node, mut buffer, mut actions_queue, mut ime_state, maybe_filter) in
+        query.iter_mut()
+    {
         let TextInputBuffer {
             editor, changes, ..
         } = &mut *buffer;
@@ -614,6 +621,47 @@ pub fn process_text_input_queues(
                         maybe_filter,
                     );
                 }
+                TextInputAction::ImePreedit { value } => {
+                    // Remove previous preedit text if any
+                    remove_preedit_text(&mut editor, &mut ime_state);
+
+                    if value.is_empty() {
+                        // Composition cancelled
+                        ime_state.preedit = None;
+                        ime_state.saved_cursor = None;
+                        ime_state.preedit_char_count = 0;
+                    } else {
+                        // Save cursor position before inserting preedit text
+                        let char_count = value.chars().count();
+                        let saved = editor.cursor();
+                        editor.insert_string(&value, None);
+
+                        ime_state.preedit = Some(value);
+                        ime_state.saved_cursor = Some(saved);
+                        ime_state.preedit_char_count = char_count;
+                    }
+                    editor.set_redraw(true);
+                }
+                TextInputAction::ImeCommit { value } => {
+                    // Remove preedit text first
+                    remove_preedit_text(&mut editor, &mut ime_state);
+
+                    // Insert committed text normally (with undo tracking, filter, max_chars)
+                    if !value.is_empty() {
+                        apply_text_input_edit(
+                            TextInputEdit::Paste(value),
+                            &mut editor,
+                            changes,
+                            node.max_chars,
+                            maybe_filter,
+                        );
+                    }
+
+                    // Clear IME state
+                    ime_state.preedit = None;
+                    ime_state.saved_cursor = None;
+                    ime_state.preedit_char_count = 0;
+                }
             }
         }
     }
@@ -621,10 +669,22 @@ pub fn process_text_input_queues(
 
 pub fn on_focused_keyboard_input(
     trigger: On<FocusedInput<KeyboardInput>>,
-    mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
+    mut query: Query<(&TextInputNode, &mut TextInputQueue, &TextInputImeState)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
-    if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
+    if let Ok((input, mut queue, ime_state)) = query.get_mut(trigger.focused_entity) {
+        // Suppress keyboard input while IME is composing — the IME handles these keys
+        if ime_state.preedit.is_some() {
+            let key = &trigger.event().input.logical_key;
+            if matches!(
+                key,
+                Key::Character(_) | Key::Space | Key::Backspace | Key::Delete | Key::Enter
+            ) && trigger.event().input.state.is_pressed()
+            {
+                return;
+            }
+        }
+
         let TextInputGlobalState {
             shift,
             overwrite_mode,
@@ -640,5 +700,125 @@ pub fn on_focused_keyboard_input(
                 queue.add(action);
             },
         );
+    }
+}
+
+/// Remove previously inserted preedit text from the editor using selection-based deletion.
+/// This is more robust than backspace-counting since it doesn't depend on cursor position.
+fn remove_preedit_text(
+    editor: &mut BorrowedWithFontSystem<Editor>,
+    ime_state: &mut TextInputImeState,
+) {
+    if ime_state.preedit_char_count > 0 {
+        if let Some(saved_cursor) = ime_state.saved_cursor {
+            // Select from saved cursor (before preedit) to current cursor (after preedit)
+            // The current cursor is at the end of the preedit text
+            let current_cursor = editor.cursor();
+            editor.set_cursor(saved_cursor);
+            editor.set_selection(Selection::Normal(current_cursor));
+            editor.delete_selection();
+        } else {
+            // Fallback: use backspace if we don't have a saved cursor
+            for _ in 0..ime_state.preedit_char_count {
+                editor.action(Action::Backspace);
+            }
+        }
+        ime_state.preedit_char_count = 0;
+        ime_state.saved_cursor = None;
+    }
+}
+
+/// Enables or disables IME on the window based on whether a text input is focused.
+/// Sets `ime_position` to just below the text cursor. The position is only updated
+/// when no preedit is active, so it stays fixed during composition.
+pub fn ime_focus_system(
+    input_focus: Res<InputFocus>,
+    text_input_query: Query<
+        (
+            &TextInputBuffer,
+            &ComputedNode,
+            &UiGlobalTransform,
+            &TextInputImeState,
+        ),
+        With<TextInputNode>,
+    >,
+    mut window_query: Query<&mut Window>,
+) {
+    if let Some(focused) = input_focus.0 {
+        if let Ok((buffer, node, transform, ime_state)) = text_input_query.get(focused) {
+            if let Some(mut window) = window_query.iter_mut().next() {
+                window.ime_enabled = true;
+                // Only update position when not composing, so the candidate
+                // box stays fixed once composition starts.
+                if ime_state.preedit.is_none() {
+                    if let Some((cx, cy)) = buffer.editor.cursor_position() {
+                        let rect = Rect::from_center_size(transform.translation, node.size());
+                        let line_height = buffer.editor.with_buffer(|b| b.metrics().line_height);
+                        window.ime_position = Vec2::new(
+                            rect.min.x + cx as f32,
+                            rect.min.y + cy as f32 + line_height * 0.8,
+                        );
+                    }
+                }
+            }
+            return;
+        }
+    }
+    // No text input focused — disable IME
+    for mut window in window_query.iter_mut() {
+        if window.ime_enabled {
+            window.ime_enabled = false;
+        }
+    }
+}
+
+/// Reads `Ime` messages and routes them to the focused text input's action queue.
+pub fn ime_event_system(
+    mut ime_reader: MessageReader<Ime>,
+    input_focus: Res<InputFocus>,
+    mut query: Query<&mut TextInputQueue, With<TextInputNode>>,
+) {
+    for ime in ime_reader.read() {
+        let Some(focused) = input_focus.0 else {
+            continue;
+        };
+        let Ok(mut queue) = query.get_mut(focused) else {
+            continue;
+        };
+        match ime {
+            Ime::Preedit { value, .. } => {
+                queue.add(TextInputAction::ImePreedit {
+                    value: value.clone(),
+                });
+            }
+            Ime::Commit { value, .. } => {
+                queue.add(TextInputAction::ImeCommit {
+                    value: value.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Cancels preedit text when the text input loses focus.
+pub fn ime_cleanup_on_unfocus_system(
+    input_focus: Res<InputFocus>,
+    mut query: Query<(Entity, &mut TextInputImeState, &mut TextInputBuffer), With<TextInputNode>>,
+    mut text_input_pipeline: ResMut<TextInputPipeline>,
+) {
+    for (entity, mut ime_state, mut buffer) in query.iter_mut() {
+        if ime_state.preedit.is_some() {
+            let is_focused = input_focus.0.is_some_and(|f| f == entity);
+            if !is_focused {
+                let mut editor = buffer
+                    .editor
+                    .borrow_with(&mut text_input_pipeline.font_system);
+                remove_preedit_text(&mut editor, &mut ime_state);
+                ime_state.preedit = None;
+                ime_state.saved_cursor = None;
+                ime_state.preedit_char_count = 0;
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ pub mod clipboard;
 pub mod edit;
 pub mod render;
 pub mod text_input_pipeline;
+#[cfg(target_os = "android")]
+pub mod android;
 
 use std::collections::VecDeque;
 
@@ -73,6 +75,20 @@ impl Plugin for TextInputPlugin {
                 ),
             );
 
+        #[cfg(target_os = "android")]
+        app.add_systems(
+            PostUpdate,
+            (
+                android::android_text_input_poll_system
+                    .after(ime_event_system)
+                    .before(process_text_input_queues),
+                android::android_text_input_sync_system
+                    .after(process_text_input_queues)
+                    .before(update_text_input_contents),
+            )
+            .in_set(UiSystems::PostLayout),
+        );
+        
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
@@ -146,6 +162,13 @@ fn on_add_textinputnode(mut world: DeferredWorld, context: HookContext) {
         Observer::new(on_move_clear_multi_click),
         Observer::new(on_focused_keyboard_input),
     ] {
+        observer.watch_entity(context.entity);
+        world.commands().spawn(observer);
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        let mut observer = Observer::new(android::on_text_input_pressed_android);
         observer.watch_entity(context.entity);
         world.commands().spawn(observer);
     }
@@ -458,6 +481,7 @@ pub struct TextInputGlobalState {
     pub command: bool,
     /// If true typed glyphs overwrite the glyph at the current cursor position, instead of inserting before it.
     pub overwrite_mode: bool,
+    pub last_android_text: String,
 }
 
 /// Queued `TextInputActions` to be processed by `process_text_input_queues` and applied to the `TextInputBuffer`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
 use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
-    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    cursor_blink_system, ime_cleanup_on_unfocus_system, ime_event_system, ime_focus_system,
+    mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input, on_move_clear_multi_click,
+    on_multi_click_set_selection, on_text_input_pressed, process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -60,6 +60,9 @@ impl Plugin for TextInputPlugin {
                     (
                         cursor_blink_system,
                         mouse_wheel_scroll,
+                        ime_cleanup_on_unfocus_system,
+                        ime_focus_system,
+                        ime_event_system,
                         process_text_input_queues,
                         update_text_input_contents,
                         text_input_system,
@@ -93,7 +96,8 @@ impl Plugin for TextInputPlugin {
     TextInputStyle,
     TextColor,
     TextInputQueue,
-    LineHeight
+    LineHeight,
+    TextInputImeState
 )]
 #[component(
     on_add = on_add_textinputnode,
@@ -297,6 +301,18 @@ impl Default for TextInputBuffer {
     }
 }
 
+/// Tracks IME (Input Method Editor) composition state for a text input.
+#[derive(Component, Default, Debug)]
+pub struct TextInputImeState {
+    /// The current preedit (composing) text, if any.
+    pub preedit: Option<String>,
+    /// Saved cursor position from before preedit text was inserted.
+    /// Used for selection-based removal of preedit text.
+    pub(crate) saved_cursor: Option<cosmic_text::Cursor>,
+    /// Number of characters inserted as preedit (for removal).
+    pub preedit_char_count: usize,
+}
+
 /// Prompt displayed when the input is empty (including whitespace).
 /// Optional component.
 #[derive(Component, Clone, Debug, Reflect)]
@@ -350,6 +366,11 @@ pub struct TextInputStyle {
     pub cursor_height: f32,
     /// Time cursor blinks in seconds
     pub blink_interval: f32,
+    /// Color of the underline drawn beneath preedit (composing) text.
+    /// Defaults to `Color::NONE`, which follows the `TextColor`.
+    pub preedit_underline_color: Color,
+    /// Thickness of the preedit underline in logical pixels.
+    pub preedit_underline_thickness: f32,
 }
 
 impl Default for TextInputStyle {
@@ -362,6 +383,8 @@ impl Default for TextInputStyle {
             cursor_radius: 0.,
             cursor_height: 1.,
             blink_interval: 0.5,
+            preedit_underline_color: Color::NONE,
+            preedit_underline_thickness: 1.,
         }
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,6 @@
 use crate::TextInputBuffer;
 use crate::TextInputGlyph;
+use crate::TextInputImeState;
 use crate::TextInputLayoutInfo;
 use crate::TextInputNode;
 use crate::TextInputPrompt;
@@ -57,6 +58,7 @@ pub fn extract_text_input_nodes(
             &TextInputStyle,
             &TextInputNode,
             &TextInputBuffer,
+            &TextInputImeState,
         )>,
     >,
     camera_map: Extract<UiCameraMap>,
@@ -78,6 +80,7 @@ pub fn extract_text_input_nodes(
         style,
         input,
         input_buffer,
+        ime_state,
     ) in &uinode_query
     {
         // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
@@ -209,6 +212,66 @@ pub fn extract_text_input_nodes(
 
             start = end;
             end += 1;
+        }
+
+        // Draw preedit underline beneath composing text
+        if ime_state.preedit.is_some() && ime_state.preedit_char_count > 0 {
+            let total_glyphs = text_layout_info.glyphs.len();
+            // Preedit glyphs are the last N glyphs (they were inserted at the cursor)
+            let preedit_start_idx = total_glyphs.saturating_sub(ime_state.preedit_char_count);
+            if preedit_start_idx < total_glyphs {
+                // Find the horizontal extent of preedit glyphs and the line index.
+                // Glyph position is center-based, so left edge = position.x - size.x * 0.5
+                let mut min_x = f32::MAX;
+                let mut max_x = f32::MIN;
+                let mut preedit_line_index = 0usize;
+                for glyph in &text_layout_info.glyphs[preedit_start_idx..] {
+                    let half_w = glyph.size.x * 0.5;
+                    min_x = min_x.min(glyph.position.x - half_w);
+                    max_x = max_x.max(glyph.position.x + half_w);
+                    preedit_line_index = glyph.line_index;
+                }
+                if min_x < max_x {
+                    // Use a consistent y based on line_height, not individual glyph bounds.
+                    let underline_y = (preedit_line_index + 1) as f32 * line_height;
+                    let underline_width = max_x - min_x;
+                    let underline_center_x = (min_x + max_x) * 0.5;
+                    let underline_center_y = underline_y + style.preedit_underline_thickness * 0.5;
+                    // Use dedicated preedit color if set, otherwise follow text color
+                    let underline_color =
+                        if style.preedit_underline_color != bevy::color::Color::NONE {
+                            LinearRgba::from(style.preedit_underline_color)
+                        } else {
+                            color
+                        };
+                    extracted_uinodes.uinodes.push(ExtractedUiNode {
+                        z_order: uinode.stack_index as f32 + stack_z_offsets::TEXT,
+                        image: AssetId::default(),
+                        clip,
+                        extracted_camera_entity,
+                        transform: transform
+                            * Affine2::from_translation(Vec2::new(
+                                underline_center_x,
+                                underline_center_y,
+                            )),
+                        item: ExtractedUiItem::Node {
+                            color: underline_color,
+                            atlas_scaling: None,
+                            flip_x: false,
+                            flip_y: false,
+                            border_radius: ResolvedBorderRadius::ZERO,
+                            border: BorderRect::ZERO,
+                            node_type: NodeType::Rect,
+                            rect: Rect {
+                                min: Vec2::ZERO,
+                                max: Vec2::new(underline_width, style.preedit_underline_thickness),
+                            },
+                        },
+                        main_entity: entity.into(),
+                        render_entity: commands.spawn(TemporaryRenderEntity).id(),
+                    });
+                }
+            }
         }
 
         if let Some((x, y)) = cursor_position {


### PR DESCRIPTION
## Overview

Adds Android platform support for text input, as a workaround until
winit provides proper virtual keyboard support upstream.

## What changed and why

**Clipboard:** `arboard` does not support Android, so it is now excluded
from Android targets. Clipboard operations return `ClipboardNotSupported`
on Android — copy/paste is not available for now.

**Virtual keyboard input:** Since winit currently does not expose virtual
keyboard events on Android (even though bevy_winit has some internal
handling, it still relies on winit), text input is wired directly to
`android-activity` with the `game-activity` backend.

**Duplicate input signals:** Virtual keyboard on Android can produce
duplicate input events. `enqueue_text_diff` is used to suppress most of
these. In rare cases a duplicate may still slip through — since this is a
temporary workaround until winit gains proper Android support, it was not
investigated further. Should be sufficient for practical use.

**Opening the virtual keyboard on tap:** `on_text_input_pressed_android`
observer is registered for each text input entity. This handles the case
where a field is already focused — in that situation the normal
focus-change mechanism does not trigger the keyboard to open, so it needs
to be handled separately.