### PR TITLE
Fix stale modifier state after focus changes

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -23,6 +23,7 @@ use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
+use bevy::input::keyboard::KeyboardFocusLost;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
@@ -650,6 +651,19 @@ pub fn on_focused_keyboard_input(
             },
         );
     }
+}
+
+pub fn clear_text_input_modifiers_on_focus_lost(
+    mut keyboard_focus_lost: MessageReader<KeyboardFocusLost>,
+    mut global_state: ResMut<TextInputGlobalState>,
+) {
+    if keyboard_focus_lost.is_empty() {
+        return;
+    }
+
+    global_state.shift = false;
+    global_state.command = false;
+    keyboard_focus_lost.clear();
 }
 
 fn sync_text_input_modifier_state(

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -4,6 +4,7 @@ use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
 use crate::TextInputGlobalState;
+use crate::TextInputKeyboardEvent;
 use crate::TextInputMode;
 use crate::TextInputNode;
 use crate::TextInputQueue;
@@ -623,17 +624,38 @@ pub fn process_text_input_queues(
     }
 }
 
-pub fn on_focused_window_event(
-    trigger: On<FocusedInput<WindowEvent>>,
+pub fn forward_text_input_keyboard_events(
+    mut window_events: MessageReader<WindowEvent>,
+    mut text_input_keyboard_events: MessageWriter<TextInputKeyboardEvent>,
+) {
+    for window_event in window_events.read() {
+        match window_event {
+            WindowEvent::KeyboardInput(keyboard_input) => {
+                text_input_keyboard_events.write(TextInputKeyboardEvent::KeyboardInput(
+                    keyboard_input.clone(),
+                ));
+            }
+            WindowEvent::KeyboardFocusLost(keyboard_focus_lost) => {
+                text_input_keyboard_events.write(TextInputKeyboardEvent::KeyboardFocusLost(
+                    keyboard_focus_lost.clone(),
+                ));
+            }
+            _ => {}
+        }
+    }
+}
+
+pub fn on_focused_text_input_keyboard_event(
+    trigger: On<FocusedInput<TextInputKeyboardEvent>>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
     match &trigger.event().input {
-        WindowEvent::KeyboardFocusLost(_) => {
+        TextInputKeyboardEvent::KeyboardFocusLost(_) => {
             global_state.shift = false;
             global_state.command = false;
         }
-        WindowEvent::KeyboardInput(keyboard_input) => {
+        TextInputKeyboardEvent::KeyboardInput(keyboard_input) => {
             let event_target = trigger.event_target();
             if event_target != trigger.original_event_target() {
                 return;
@@ -646,20 +668,20 @@ pub fn on_focused_window_event(
                 &mut global_state,
             );
         }
-        _ => {}
     }
 }
 
 pub fn on_raw_keyboard_input_fallback(
     mut keyboard_inputs: MessageReader<KeyboardInput>,
-    mut window_events: MessageReader<WindowEvent>,
+    mut text_input_keyboard_events: MessageReader<TextInputKeyboardEvent>,
     input_focus: Res<InputFocus>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
     let mut window_keyboard_inputs = HashMap::<KeyboardInput, usize>::new();
-    for window_event in window_events.read() {
-        let WindowEvent::KeyboardInput(keyboard_input) = window_event else {
+    for text_input_keyboard_event in text_input_keyboard_events.read() {
+        let TextInputKeyboardEvent::KeyboardInput(keyboard_input) = text_input_keyboard_event
+        else {
             continue;
         };
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -20,7 +20,6 @@ use bevy::ecs::system::Commands;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
-use bevy::input::ButtonInput;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
@@ -646,18 +645,22 @@ pub fn on_focused_keyboard_input(
 }
 
 pub fn sync_text_input_modifier_state(
-    key_input: Res<ButtonInput<Key>>,
+    mut keyboard_input_events: MessageReader<KeyboardInput>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
-    global_state.shift = key_input.pressed(Key::Shift);
-
-    #[cfg(target_os = "macos")]
-    {
-        global_state.command = key_input.pressed(Key::Control) || key_input.pressed(Key::Super);
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        global_state.command = key_input.pressed(Key::Control);
+    for keyboard_input in keyboard_input_events.read() {
+        match keyboard_input.logical_key {
+            Key::Shift => {
+                global_state.shift = keyboard_input.state == ButtonState::Pressed;
+            }
+            Key::Control => {
+                global_state.command = keyboard_input.state == ButtonState::Pressed;
+            }
+            #[cfg(target_os = "macos")]
+            Key::Super => {
+                global_state.command = keyboard_input.state == ButtonState::Pressed;
+            }
+            _ => {}
+        }
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -13,6 +13,7 @@ use crate::clipboard::Clipboard;
 use crate::text_input_pipeline::TextInputPipeline;
 use bevy::ecs::component::Component;
 use bevy::ecs::entity::Entity;
+use bevy::ecs::event::EntityEvent;
 use bevy::ecs::message::MessageReader;
 use bevy::ecs::message::MessageWriter;
 use bevy::ecs::observer::On;
@@ -626,11 +627,12 @@ pub fn on_focused_keyboard_input(
 ) {
     sync_text_input_modifier_state(&trigger.event().input, &mut global_state);
 
-    if trigger.focused_entity != trigger.original_event_target() {
+    let event_target = trigger.event_target();
+    if event_target != trigger.original_event_target() {
         return;
     }
 
-    if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
+    if let Ok((input, mut queue)) = query.get_mut(event_target) {
         let TextInputGlobalState {
             shift,
             overwrite_mode,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -626,6 +626,10 @@ pub fn on_focused_keyboard_input(
 ) {
     sync_text_input_modifier_state(&trigger.event().input, &mut global_state);
 
+    if trigger.focused_entity != trigger.original_event_target() {
+        return;
+    }
+
     if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
         let TextInputGlobalState {
             shift,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
@@ -676,16 +678,20 @@ pub fn on_raw_keyboard_input_fallback(
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
-    let saw_forwarded_keyboard_input = text_input_keyboard_events
+    let mut forwarded_keyboard_inputs = text_input_keyboard_events
         .read()
-        .any(|event| matches!(event, TextInputKeyboardEvent::KeyboardInput(_)));
-
-    if saw_forwarded_keyboard_input {
-        keyboard_inputs.clear();
-        return;
-    }
+        .filter_map(|event| match event {
+            TextInputKeyboardEvent::KeyboardInput(keyboard_input) => Some(keyboard_input.clone()),
+            TextInputKeyboardEvent::KeyboardFocusLost(_) => None,
+        })
+        .collect::<VecDeque<_>>();
 
     for keyboard_input in keyboard_inputs.read() {
+        if forwarded_keyboard_inputs.front() == Some(keyboard_input) {
+            forwarded_keyboard_inputs.pop_front();
+            continue;
+        }
+
         handle_keyboard_input(
             keyboard_input,
             input_focus.get(),

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
@@ -632,33 +634,86 @@ pub fn on_focused_window_event(
             global_state.command = false;
         }
         WindowEvent::KeyboardInput(keyboard_input) => {
-            sync_text_input_modifier_state(keyboard_input, &mut global_state);
-
             let event_target = trigger.event_target();
             if event_target != trigger.original_event_target() {
                 return;
             }
 
-            if let Ok((input, mut queue)) = query.get_mut(event_target) {
-                let TextInputGlobalState {
-                    shift,
-                    overwrite_mode,
-                    command,
-                } = &mut *global_state;
-
-                queue_text_input_action(
-                    &input.mode,
-                    shift,
-                    overwrite_mode,
-                    command,
-                    keyboard_input,
-                    |action| {
-                        queue.add(action);
-                    },
-                );
-            }
+            handle_keyboard_input(
+                keyboard_input,
+                Some(event_target),
+                &mut query,
+                &mut global_state,
+            );
         }
         _ => {}
+    }
+}
+
+pub fn on_raw_keyboard_input_fallback(
+    mut keyboard_inputs: MessageReader<KeyboardInput>,
+    mut window_events: MessageReader<WindowEvent>,
+    input_focus: Res<InputFocus>,
+    mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
+    mut global_state: ResMut<TextInputGlobalState>,
+) {
+    let mut window_keyboard_inputs = HashMap::<KeyboardInput, usize>::new();
+    for window_event in window_events.read() {
+        let WindowEvent::KeyboardInput(keyboard_input) = window_event else {
+            continue;
+        };
+
+        *window_keyboard_inputs
+            .entry(keyboard_input.clone())
+            .or_default() += 1;
+    }
+
+    for keyboard_input in keyboard_inputs.read() {
+        if let Some(seen_count) = window_keyboard_inputs.get_mut(keyboard_input)
+            && *seen_count > 0
+        {
+            *seen_count -= 1;
+            continue;
+        }
+
+        handle_keyboard_input(
+            keyboard_input,
+            input_focus.get(),
+            &mut query,
+            &mut global_state,
+        );
+    }
+}
+
+fn handle_keyboard_input(
+    keyboard_input: &KeyboardInput,
+    target: Option<Entity>,
+    query: &mut Query<(&TextInputNode, &mut TextInputQueue)>,
+    global_state: &mut TextInputGlobalState,
+) {
+    sync_text_input_modifier_state(keyboard_input, global_state);
+
+    let Some(target) = target else {
+        return;
+    };
+
+    if let Ok((input, mut queue)) = query.get_mut(target) {
+        let TextInputGlobalState {
+            shift,
+            overwrite_mode,
+            command,
+        } = global_state;
+
+        queue_text_input_action(
+            &input.mode,
+            shift,
+            overwrite_mode,
+            command,
+            keyboard_input,
+            |action| {
+                queue.add(action);
+            },
+        );
     }
 }
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -20,6 +20,7 @@ use bevy::ecs::system::Commands;
 use bevy::ecs::system::Query;
 use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
+use bevy::input::ButtonInput;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
@@ -622,14 +623,28 @@ pub fn process_text_input_queues(
 pub fn on_focused_keyboard_input(
     trigger: On<FocusedInput<KeyboardInput>>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
+    key_input: Res<ButtonInput<Key>>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
     if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
+        global_state.shift = key_input.pressed(Key::Shift);
+
+        #[cfg(target_os = "macos")]
+        {
+            global_state.command = key_input.pressed(Key::Control) || key_input.pressed(Key::Super);
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            global_state.command = key_input.pressed(Key::Control);
+        }
+
         let TextInputGlobalState {
             shift,
             overwrite_mode,
             command,
         } = &mut *global_state;
+
         queue_text_input_action(
             &input.mode,
             shift,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
@@ -24,6 +26,7 @@ use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
+use bevy::input::keyboard::KeyboardFocusLost;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
@@ -671,18 +674,29 @@ pub(super) fn on_focused_text_input_keyboard_event(
 
 pub(super) fn on_raw_keyboard_input_fallback(
     mut keyboard_inputs: MessageReader<KeyboardInput>,
+    mut keyboard_focus_lost: MessageReader<KeyboardFocusLost>,
     mut text_input_keyboard_events: MessageReader<TextInputKeyboardEvent>,
     input_focus: Res<InputFocus>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
+    let saw_forwarded_keyboard_focus_lost = Cell::new(false);
     let mut forwarded_keyboard_inputs = text_input_keyboard_events
         .read()
         .filter_map(|event| match event {
             TextInputKeyboardEvent::KeyboardInput(keyboard_input) => Some(keyboard_input),
-            TextInputKeyboardEvent::KeyboardFocusLost(_) => None,
+            TextInputKeyboardEvent::KeyboardFocusLost(_) => {
+                saw_forwarded_keyboard_focus_lost.set(true);
+                None
+            }
         })
         .peekable();
+
+    let saw_raw_keyboard_focus_lost = keyboard_focus_lost.read().count() != 0;
+    if saw_raw_keyboard_focus_lost && !saw_forwarded_keyboard_focus_lost.get() {
+        global_state.shift = false;
+        global_state.command = false;
+    }
 
     for keyboard_input in keyboard_inputs.read() {
         if forwarded_keyboard_inputs

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -623,22 +623,9 @@ pub fn process_text_input_queues(
 pub fn on_focused_keyboard_input(
     trigger: On<FocusedInput<KeyboardInput>>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
-    key_input: Res<ButtonInput<Key>>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
     if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
-        global_state.shift = key_input.pressed(Key::Shift);
-
-        #[cfg(target_os = "macos")]
-        {
-            global_state.command = key_input.pressed(Key::Control) || key_input.pressed(Key::Super);
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            global_state.command = key_input.pressed(Key::Control);
-        }
-
         let TextInputGlobalState {
             shift,
             overwrite_mode,
@@ -655,5 +642,22 @@ pub fn on_focused_keyboard_input(
                 queue.add(action);
             },
         );
+    }
+}
+
+pub fn sync_text_input_modifier_state(
+    key_input: Res<ButtonInput<Key>>,
+    mut global_state: ResMut<TextInputGlobalState>,
+) {
+    global_state.shift = key_input.pressed(Key::Shift);
+
+    #[cfg(target_os = "macos")]
+    {
+        global_state.command = key_input.pressed(Key::Control) || key_input.pressed(Key::Super);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        global_state.command = key_input.pressed(Key::Control);
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -624,6 +624,8 @@ pub fn on_focused_keyboard_input(
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
+    sync_text_input_modifier_state(&trigger.event().input, &mut global_state);
+
     if let Ok((input, mut queue)) = query.get_mut(trigger.focused_entity) {
         let TextInputGlobalState {
             shift,
@@ -644,23 +646,21 @@ pub fn on_focused_keyboard_input(
     }
 }
 
-pub fn sync_text_input_modifier_state(
-    mut keyboard_input_events: MessageReader<KeyboardInput>,
-    mut global_state: ResMut<TextInputGlobalState>,
+fn sync_text_input_modifier_state(
+    keyboard_input: &KeyboardInput,
+    global_state: &mut TextInputGlobalState,
 ) {
-    for keyboard_input in keyboard_input_events.read() {
-        match keyboard_input.logical_key {
-            Key::Shift => {
-                global_state.shift = keyboard_input.state == ButtonState::Pressed;
-            }
-            Key::Control => {
-                global_state.command = keyboard_input.state == ButtonState::Pressed;
-            }
-            #[cfg(target_os = "macos")]
-            Key::Super => {
-                global_state.command = keyboard_input.state == ButtonState::Pressed;
-            }
-            _ => {}
+    match keyboard_input.logical_key {
+        Key::Shift => {
+            global_state.shift = keyboard_input.state == ButtonState::Pressed;
         }
+        Key::Control => {
+            global_state.command = keyboard_input.state == ButtonState::Pressed;
+        }
+        #[cfg(target_os = "macos")]
+        Key::Super => {
+            global_state.command = keyboard_input.state == ButtonState::Pressed;
+        }
+        _ => {}
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
@@ -678,26 +676,16 @@ pub fn on_raw_keyboard_input_fallback(
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
-    let mut window_keyboard_inputs = HashMap::<KeyboardInput, usize>::new();
-    for text_input_keyboard_event in text_input_keyboard_events.read() {
-        let TextInputKeyboardEvent::KeyboardInput(keyboard_input) = text_input_keyboard_event
-        else {
-            continue;
-        };
+    let saw_forwarded_keyboard_input = text_input_keyboard_events
+        .read()
+        .any(|event| matches!(event, TextInputKeyboardEvent::KeyboardInput(_)));
 
-        *window_keyboard_inputs
-            .entry(keyboard_input.clone())
-            .or_default() += 1;
+    if saw_forwarded_keyboard_input {
+        keyboard_inputs.clear();
+        return;
     }
 
     for keyboard_input in keyboard_inputs.read() {
-        if let Some(seen_count) = window_keyboard_inputs.get_mut(keyboard_input)
-            && *seen_count > 0
-        {
-            *seen_count -= 1;
-            continue;
-        }
-
         handle_keyboard_input(
             keyboard_input,
             input_focus.get(),

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -23,7 +23,6 @@ use bevy::ecs::system::Res;
 use bevy::ecs::system::ResMut;
 use bevy::input::ButtonState;
 use bevy::input::keyboard::Key;
-use bevy::input::keyboard::KeyboardFocusLost;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::mouse::MouseWheel;
@@ -40,6 +39,7 @@ use bevy::picking::pointer::PointerButton;
 use bevy::time::Time;
 use bevy::ui::ComputedNode;
 use bevy::ui::UiGlobalTransform;
+use bevy::window::WindowEvent;
 use cosmic_text::Action;
 use cosmic_text::BorrowedWithFontSystem;
 use cosmic_text::Change;
@@ -621,49 +621,45 @@ pub fn process_text_input_queues(
     }
 }
 
-pub fn on_focused_keyboard_input(
-    trigger: On<FocusedInput<KeyboardInput>>,
+pub fn on_focused_window_event(
+    trigger: On<FocusedInput<WindowEvent>>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
 ) {
-    sync_text_input_modifier_state(&trigger.event().input, &mut global_state);
+    match &trigger.event().input {
+        WindowEvent::KeyboardFocusLost(_) => {
+            global_state.shift = false;
+            global_state.command = false;
+        }
+        WindowEvent::KeyboardInput(keyboard_input) => {
+            sync_text_input_modifier_state(keyboard_input, &mut global_state);
 
-    let event_target = trigger.event_target();
-    if event_target != trigger.original_event_target() {
-        return;
+            let event_target = trigger.event_target();
+            if event_target != trigger.original_event_target() {
+                return;
+            }
+
+            if let Ok((input, mut queue)) = query.get_mut(event_target) {
+                let TextInputGlobalState {
+                    shift,
+                    overwrite_mode,
+                    command,
+                } = &mut *global_state;
+
+                queue_text_input_action(
+                    &input.mode,
+                    shift,
+                    overwrite_mode,
+                    command,
+                    keyboard_input,
+                    |action| {
+                        queue.add(action);
+                    },
+                );
+            }
+        }
+        _ => {}
     }
-
-    if let Ok((input, mut queue)) = query.get_mut(event_target) {
-        let TextInputGlobalState {
-            shift,
-            overwrite_mode,
-            command,
-        } = &mut *global_state;
-
-        queue_text_input_action(
-            &input.mode,
-            shift,
-            overwrite_mode,
-            command,
-            &trigger.event().input,
-            |action| {
-                queue.add(action);
-            },
-        );
-    }
-}
-
-pub fn clear_text_input_modifiers_on_focus_lost(
-    mut keyboard_focus_lost: MessageReader<KeyboardFocusLost>,
-    mut global_state: ResMut<TextInputGlobalState>,
-) {
-    if keyboard_focus_lost.is_empty() {
-        return;
-    }
-
-    global_state.shift = false;
-    global_state.command = false;
-    keyboard_focus_lost.clear();
 }
 
 fn sync_text_input_modifier_state(

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use crate::SubmitText;
 use crate::TextInputBuffer;
 use crate::TextInputFilter;
@@ -624,7 +622,7 @@ pub fn process_text_input_queues(
     }
 }
 
-pub fn forward_text_input_keyboard_events(
+pub(super) fn forward_text_input_keyboard_events(
     mut window_events: MessageReader<WindowEvent>,
     mut text_input_keyboard_events: MessageWriter<TextInputKeyboardEvent>,
 ) {
@@ -645,7 +643,7 @@ pub fn forward_text_input_keyboard_events(
     }
 }
 
-pub fn on_focused_text_input_keyboard_event(
+pub(super) fn on_focused_text_input_keyboard_event(
     trigger: On<FocusedInput<TextInputKeyboardEvent>>,
     mut query: Query<(&TextInputNode, &mut TextInputQueue)>,
     mut global_state: ResMut<TextInputGlobalState>,
@@ -671,7 +669,7 @@ pub fn on_focused_text_input_keyboard_event(
     }
 }
 
-pub fn on_raw_keyboard_input_fallback(
+pub(super) fn on_raw_keyboard_input_fallback(
     mut keyboard_inputs: MessageReader<KeyboardInput>,
     mut text_input_keyboard_events: MessageReader<TextInputKeyboardEvent>,
     input_focus: Res<InputFocus>,
@@ -681,14 +679,16 @@ pub fn on_raw_keyboard_input_fallback(
     let mut forwarded_keyboard_inputs = text_input_keyboard_events
         .read()
         .filter_map(|event| match event {
-            TextInputKeyboardEvent::KeyboardInput(keyboard_input) => Some(keyboard_input.clone()),
+            TextInputKeyboardEvent::KeyboardInput(keyboard_input) => Some(keyboard_input),
             TextInputKeyboardEvent::KeyboardFocusLost(_) => None,
         })
-        .collect::<VecDeque<_>>();
+        .peekable();
 
     for keyboard_input in keyboard_inputs.read() {
-        if forwarded_keyboard_inputs.front() == Some(keyboard_input) {
-            forwarded_keyboard_inputs.pop_front();
+        if forwarded_keyboard_inputs
+            .next_if(|forwarded_keyboard_input| *forwarded_keyboard_input == keyboard_input)
+            .is_some()
+        {
             continue;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod text_input_pipeline;
 use std::collections::VecDeque;
 
 use actions::TextInputAction;
-use bevy::app::{Plugin, PostUpdate};
+use bevy::app::{Plugin, PostUpdate, PreUpdate};
 use bevy::asset::AssetEventSystems;
 use bevy::color::Color;
 use bevy::color::palettes::css::SKY_BLUE;
@@ -22,7 +22,8 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
-use bevy::input_focus::InputFocus;
+use bevy::input::InputSystems;
+use bevy::input_focus::{InputFocus, InputFocusSystems};
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::ReflectComponent;
 use bevy::reflect::{Reflect, std_traits::ReflectDefault};
@@ -35,7 +36,7 @@ use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
     cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
     on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    process_text_input_queues, sync_text_input_modifier_state,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -52,6 +53,12 @@ impl Plugin for TextInputPlugin {
             .init_resource::<TextInputGlobalState>()
             .init_resource::<TextInputPipeline>()
             .init_resource::<clipboard::Clipboard>()
+            .add_systems(
+                PreUpdate,
+                sync_text_input_modifier_state
+                    .after(InputSystems)
+                    .before(InputFocusSystems::Dispatch),
+            )
             .add_systems(
                 PostUpdate,
                 (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
     cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
     on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues, sync_text_input_modifier_state,
+    process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -52,10 +52,10 @@ impl Plugin for TextInputPlugin {
             .init_resource::<TextInputGlobalState>()
             .init_resource::<TextInputPipeline>()
             .init_resource::<clipboard::Clipboard>()
+            .add_observer(on_focused_keyboard_input)
             .add_systems(
                 PostUpdate,
                 (
-                    sync_text_input_modifier_state,
                     remove_dropped_font_atlas_sets_from_text_input_pipeline
                         .before(AssetEventSystems),
                     (
@@ -141,7 +141,6 @@ fn on_add_textinputnode(mut world: DeferredWorld, context: HookContext) {
         Observer::new(on_text_input_pressed),
         Observer::new(on_multi_click_set_selection),
         Observer::new(on_move_clear_multi_click),
-        Observer::new(on_focused_keyboard_input),
     ] {
         observer.watch_entity(context.entity);
         world.commands().spawn(observer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,7 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
-use bevy::input::InputSystems;
-use bevy::input_focus::{InputFocus, InputFocusSystems};
+use bevy::input_focus::{InputFocus, InputFocusSystems, dispatch_focused_input};
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::ReflectComponent;
 use bevy::reflect::{Reflect, std_traits::ReflectDefault};
@@ -32,11 +31,12 @@ use bevy::text::{GlyphAtlasInfo, LineHeight, TextFont};
 use bevy::text::{Justify, TextColor};
 use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
+use bevy::window::WindowEvent;
 use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
-    clear_text_input_modifiers_on_focus_lost, cursor_blink_system, mouse_wheel_scroll,
-    on_drag_text_input, on_focused_keyboard_input, on_move_clear_multi_click,
-    on_multi_click_set_selection, on_text_input_pressed, process_text_input_queues,
+    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_window_event,
+    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
+    process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -53,12 +53,10 @@ impl Plugin for TextInputPlugin {
             .init_resource::<TextInputGlobalState>()
             .init_resource::<TextInputPipeline>()
             .init_resource::<clipboard::Clipboard>()
-            .add_observer(on_focused_keyboard_input)
+            .add_observer(on_focused_window_event)
             .add_systems(
                 PreUpdate,
-                clear_text_input_modifiers_on_focus_lost
-                    .after(InputSystems)
-                    .after(InputFocusSystems::Dispatch),
+                dispatch_focused_input::<WindowEvent>.in_set(InputFocusSystems::Dispatch),
             )
             .add_systems(
                 PostUpdate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub struct SubmitText {
 }
 
 #[derive(Message, Clone)]
-pub enum TextInputKeyboardEvent {
+enum TextInputKeyboardEvent {
     KeyboardInput(KeyboardInput),
     KeyboardFocusLost(KeyboardFocusLost),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
+use bevy::input::keyboard::{KeyboardFocusLost, KeyboardInput};
 use bevy::input_focus::{InputFocus, InputFocusSystems, dispatch_focused_input};
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::ReflectComponent;
@@ -31,12 +32,12 @@ use bevy::text::{GlyphAtlasInfo, LineHeight, TextFont};
 use bevy::text::{Justify, TextColor};
 use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
-use bevy::window::WindowEvent;
 use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
-    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_window_event,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_raw_keyboard_input_fallback,
-    on_text_input_pressed, process_text_input_queues,
+    cursor_blink_system, forward_text_input_keyboard_events, mouse_wheel_scroll,
+    on_drag_text_input, on_focused_text_input_keyboard_event, on_move_clear_multi_click,
+    on_multi_click_set_selection, on_raw_keyboard_input_fallback, on_text_input_pressed,
+    process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -49,15 +50,18 @@ pub struct TextInputPlugin;
 impl Plugin for TextInputPlugin {
     fn build(&self, app: &mut bevy::app::App) {
         app.add_message::<SubmitText>()
+            .add_message::<TextInputKeyboardEvent>()
             .add_plugins(bevy::input_focus::InputDispatchPlugin)
             .init_resource::<TextInputGlobalState>()
             .init_resource::<TextInputPipeline>()
             .init_resource::<clipboard::Clipboard>()
-            .add_observer(on_focused_window_event)
+            .add_observer(on_focused_text_input_keyboard_event)
             .add_systems(
                 PreUpdate,
                 (
-                    dispatch_focused_input::<WindowEvent>.in_set(InputFocusSystems::Dispatch),
+                    forward_text_input_keyboard_events.before(InputFocusSystems::Dispatch),
+                    dispatch_focused_input::<TextInputKeyboardEvent>
+                        .in_set(InputFocusSystems::Dispatch),
                     on_raw_keyboard_input_fallback.after(InputFocusSystems::Dispatch),
                 ),
             )
@@ -172,6 +176,12 @@ pub struct SubmitText {
     pub entity: Entity,
     /// The submitted text
     pub text: String,
+}
+
+#[derive(Message, Clone)]
+pub enum TextInputKeyboardEvent {
+    KeyboardInput(KeyboardInput),
+    KeyboardFocusLost(KeyboardFocusLost),
 }
 
 /// Mode of text input

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod text_input_pipeline;
 use std::collections::VecDeque;
 
 use actions::TextInputAction;
-use bevy::app::{Plugin, PostUpdate, PreUpdate};
+use bevy::app::{Plugin, PostUpdate};
 use bevy::asset::AssetEventSystems;
 use bevy::color::Color;
 use bevy::color::palettes::css::SKY_BLUE;
@@ -22,8 +22,7 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
-use bevy::input::InputSystems;
-use bevy::input_focus::{InputFocus, InputFocusSystems};
+use bevy::input_focus::InputFocus;
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::ReflectComponent;
 use bevy::reflect::{Reflect, std_traits::ReflectDefault};
@@ -54,14 +53,9 @@ impl Plugin for TextInputPlugin {
             .init_resource::<TextInputPipeline>()
             .init_resource::<clipboard::Clipboard>()
             .add_systems(
-                PreUpdate,
-                sync_text_input_modifier_state
-                    .after(InputSystems)
-                    .before(InputFocusSystems::Dispatch),
-            )
-            .add_systems(
                 PostUpdate,
                 (
+                    sync_text_input_modifier_state,
                     remove_dropped_font_atlas_sets_from_text_input_pipeline
                         .before(AssetEventSystems),
                     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ use bevy::window::WindowEvent;
 use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
     cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_window_event,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    on_move_clear_multi_click, on_multi_click_set_selection, on_raw_keyboard_input_fallback,
+    on_text_input_pressed, process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -56,7 +56,10 @@ impl Plugin for TextInputPlugin {
             .add_observer(on_focused_window_event)
             .add_systems(
                 PreUpdate,
-                dispatch_focused_input::<WindowEvent>.in_set(InputFocusSystems::Dispatch),
+                (
+                    dispatch_focused_input::<WindowEvent>.in_set(InputFocusSystems::Dispatch),
+                    on_raw_keyboard_input_fallback.after(InputFocusSystems::Dispatch),
+                ),
             )
             .add_systems(
                 PostUpdate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod text_input_pipeline;
 use std::collections::VecDeque;
 
 use actions::TextInputAction;
-use bevy::app::{Plugin, PostUpdate};
+use bevy::app::{Plugin, PostUpdate, PreUpdate};
 use bevy::asset::AssetEventSystems;
 use bevy::color::Color;
 use bevy::color::palettes::css::SKY_BLUE;
@@ -22,7 +22,8 @@ use bevy::ecs::resource::Resource;
 use bevy::ecs::schedule::IntoScheduleConfigs;
 use bevy::ecs::system::Query;
 use bevy::ecs::world::DeferredWorld;
-use bevy::input_focus::InputFocus;
+use bevy::input::InputSystems;
+use bevy::input_focus::{InputFocus, InputFocusSystems};
 use bevy::math::{Rect, Vec2};
 use bevy::prelude::ReflectComponent;
 use bevy::reflect::{Reflect, std_traits::ReflectDefault};
@@ -33,9 +34,9 @@ use bevy::ui::{Node, UiSystems};
 use bevy::ui_render::{RenderUiSystems, extract_text_sections};
 use cosmic_text::{Buffer, Change, Edit, Editor, Metrics, Wrap};
 use edit::{
-    cursor_blink_system, mouse_wheel_scroll, on_drag_text_input, on_focused_keyboard_input,
-    on_move_clear_multi_click, on_multi_click_set_selection, on_text_input_pressed,
-    process_text_input_queues,
+    clear_text_input_modifiers_on_focus_lost, cursor_blink_system, mouse_wheel_scroll,
+    on_drag_text_input, on_focused_keyboard_input, on_move_clear_multi_click,
+    on_multi_click_set_selection, on_text_input_pressed, process_text_input_queues,
 };
 use render::{extract_text_input_nodes, extract_text_input_prompts};
 use text_input_pipeline::{
@@ -53,6 +54,12 @@ impl Plugin for TextInputPlugin {
             .init_resource::<TextInputPipeline>()
             .init_resource::<clipboard::Clipboard>()
             .add_observer(on_focused_keyboard_input)
+            .add_systems(
+                PreUpdate,
+                clear_text_input_modifiers_on_focus_lost
+                    .after(InputSystems)
+                    .after(InputFocusSystems::Dispatch),
+            )
             .add_systems(
                 PostUpdate,
                 (


### PR DESCRIPTION
## Summary
- refresh cached Shift/Ctrl-Command state from Bevy's current keyboard state before handling focused keyboard input
- fixes broken focus-change flows where the command modifier can stay stuck after paste

Example broken flow:
1. Focus one text field.
2. Paste text with Ctrl/Command+V.
3. That paste triggers app logic that moves focus to a different field.
4. Click the new field and start typing.
5. The typed characters are ignored because the crate still thinks Ctrl/Command is pressed.