### PR TITLE
Fix text input flicker when glyph atlas grows

### DIFF
--- a/src/text_input_pipeline.rs
+++ b/src/text_input_pipeline.rs
@@ -212,8 +212,10 @@ pub fn text_input_system(
         } = &mut *editor;
 
         if editor.redraw() {
-            layout_info.glyphs.clear();
-            selection_rects.clear();
+            let mut next_size = Vec2::ZERO;
+            let mut next_glyphs = Vec::new();
+            let mut next_selection_rects = Vec::new();
+            let mut atlas_changed = false;
 
             let result = editor.with_buffer_mut(|buffer| {
                 let box_size = buffer_dimensions(buffer);
@@ -225,7 +227,7 @@ pub fn text_input_system(
                         let y1 = y0 + run.line_height;
                         let x1 = x0 + w;
                         let r = Rect::new(x0, y0, x1, y1);
-                        selection_rects.push(r);
+                        next_selection_rects.push(r);
                     }
 
                     run.glyphs
@@ -264,7 +266,6 @@ pub fn text_input_system(
                             let font_atlas_set = font_atlas_sets.entry(font_id).or_default();
 
                             let physical_glyph = layout_glyph.physical((0., 0.), 1.);
-
                             let font_atlases = font_atlas_set
                                 .entry(FontAtlasKey(
                                     font_id,
@@ -284,6 +285,7 @@ pub fn text_input_system(
                                 get_glyph_atlas_info(font_atlases, physical_glyph.cache_key)
                                     .map(Ok)
                                     .unwrap_or_else(|| {
+                                        atlas_changed = true;
                                         add_glyph_to_atlas(
                                             font_atlases,
                                             &mut texture_atlases,
@@ -319,7 +321,7 @@ pub fn text_input_system(
                                 byte_length: layout_glyph.end - layout_glyph.start,
                                 line_index: line_i,
                             };
-                            layout_info.glyphs.push(pos_glyph);
+                            next_glyphs.push(pos_glyph);
                             Ok(())
                         })
                 });
@@ -327,7 +329,7 @@ pub fn text_input_system(
                 // Check result.
                 result?;
 
-                layout_info.size = box_size;
+                next_size = box_size;
                 Ok(())
             });
 
@@ -345,6 +347,13 @@ pub fn text_input_system(
                     panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(()) => {
+                    if atlas_changed {
+                        continue;
+                    }
+
+                    layout_info.size = next_size;
+                    layout_info.glyphs = next_glyphs;
+                    *selection_rects = next_selection_rects;
                     layout_info.size.x *= node.inverse_scale_factor();
                     layout_info.size.y *= node.inverse_scale_factor();
                     editor.set_redraw(false);


### PR DESCRIPTION
Text input redraws currently replace the visible glyph layout immediately after adding missing glyphs to the atlas. On native/mobile render paths, that can expose newly allocated atlas entries before the render-side texture upload is ready, producing a one-frame blank/flicker the first time a glyph/cache-key is used.

This stages the next glyph layout locally during redraw. If any glyph had to be added to the atlas, the system keeps the previous visible layout for the frame and retries the redraw next frame. Once every glyph is already cached, the staged layout replaces the visible layout and redraw is cleared.

Validated with:
- cargo check
- cargo clippy --all-targets

Note: clippy reports an existing collapsible_match warning in src/edit.rs, unrelated to this change.